### PR TITLE
Adding cell to display MHM metrics in Prompt Evaluation with watsonxgov sample Notebook

### DIFF
--- a/WatsonX.Governance/Cloud/GenAI/samples/Prompt Evaluation with watsonxgov.ipynb
+++ b/WatsonX.Governance/Cloud/GenAI/samples/Prompt Evaluation with watsonxgov.ipynb
@@ -70,14 +70,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:25:28.817395Z",
+     "start_time": "2024-09-18T13:25:28.812101Z"
+    }
+   },
    "source": [
     "!pip install --upgrade ibm-watson-openscale | tail -n 1\n",
-    "!pip install --upgrade ibm-watson-machine-learning | tail -n 1\n",
+    "!pip install --upgrade ibm-watson-ai | tail -n 1\n",
     "!pip install matplotlib"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 1
   },
   {
    "cell_type": "markdown",
@@ -124,9 +129,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:25:31.660659Z",
+     "start_time": "2024-09-18T13:25:31.657960Z"
+    }
+   },
    "source": [
     "use_cpd = False\n",
     "IAM_URL=\"https://iam.cloud.ibm.com\"\n",
@@ -139,7 +147,9 @@
     "                   \"url\": \"https://us-south.ml.cloud.ibm.com\",\n",
     "                   \"apikey\": CLOUD_API_KEY\n",
     "}"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 2
   },
   {
    "cell_type": "markdown",
@@ -150,9 +160,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:17.745165Z",
+     "start_time": "2024-09-18T10:59:17.742924Z"
+    }
+   },
    "source": [
     "# use_cpd = True\n",
     "# WOS_CREDENTIALS = {\n",
@@ -169,7 +182,9 @@
     "#                    \"apikey\": \"<EDIT THIS>\",\n",
     "#                    \"version\" : \"4.8\" #If your env is CP4D 4.x.x then specify \"4.x.x\" instead of \"4.8\"\n",
     "#                   }"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 3
   },
   {
    "cell_type": "markdown",
@@ -187,12 +202,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:18.397312Z",
+     "start_time": "2024-09-18T10:59:18.395211Z"
+    }
+   },
+   "source": "project_id = \"<EDIT THIS>\" # YOUR_PROJECT_ID",
    "outputs": [],
-   "source": [
-    "project_id = \"<EDIT THIS>\" # YOUR_PROJECT_ID"
-   ]
+   "execution_count": 4
   },
   {
    "cell_type": "markdown",
@@ -210,25 +228,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:19.053803Z",
+     "start_time": "2024-09-18T10:59:19.051327Z"
+    }
+   },
    "source": [
     "use_existing_space = True # Set it as False if user wants to create a new space"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 5
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:23.606232Z",
+     "start_time": "2024-09-18T10:59:19.311700Z"
+    }
+   },
    "source": [
     "import json\n",
-    "from ibm_watson_machine_learning import APIClient\n",
+    "from ibm_watsonx_ai import APIClient\n",
     "\n",
-    "wml_client = APIClient(WML_CREDENTIALS)\n",
-    "wml_client.version"
-   ]
+    "wx_ai_client = APIClient(WML_CREDENTIALS)\n",
+    "wx_ai_client.version"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.1.9'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 6
   },
   {
    "cell_type": "markdown",
@@ -246,21 +285,132 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "wml_client.spaces.list()"
-   ]
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:25.726664Z",
+     "start_time": "2024-09-18T10:59:24.821010Z"
+    }
+   },
+   "source": "wx_ai_client.spaces.list()",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: 'limit' is not provided. Only first 50 records will be displayed if the number of records exceed 50\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "                                     ID                  NAME  \\\n",
+       "0  bc592530-1cf0-4e56-9fab-70e0924f6907  prompt_evaluvation_s   \n",
+       "1  00883863-b2ef-4b90-b797-f5917a6618bc              Notebook   \n",
+       "2  89fd4eac-f4d2-4637-a601-118faebcaa28     v2-e2e-test-space   \n",
+       "3  fb8bd9cb-09d2-4ce9-b6ed-153076b30562              GCR_prod   \n",
+       "4  43854078-1c88-4ba9-904c-a805a4d18469              GCRSpace   \n",
+       "5  5ba115ac-70b9-455a-ba79-96d2912e4e12                  iris   \n",
+       "6  523c8856-6d1e-49aa-b371-5dab42cd322c        sdk-test-space   \n",
+       "\n",
+       "                    CREATED  \n",
+       "0  2024-09-17T15:39:39.598Z  \n",
+       "1  2024-07-16T09:30:02.576Z  \n",
+       "2  2024-07-11T06:18:12.508Z  \n",
+       "3  2024-07-09T15:33:53.617Z  \n",
+       "4  2024-07-09T15:32:03.736Z  \n",
+       "5  2024-07-05T15:39:08.106Z  \n",
+       "6  2024-06-27T09:19:53.318Z  "
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ID</th>\n",
+       "      <th>NAME</th>\n",
+       "      <th>CREATED</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bc592530-1cf0-4e56-9fab-70e0924f6907</td>\n",
+       "      <td>prompt_evaluvation_s</td>\n",
+       "      <td>2024-09-17T15:39:39.598Z</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>00883863-b2ef-4b90-b797-f5917a6618bc</td>\n",
+       "      <td>Notebook</td>\n",
+       "      <td>2024-07-16T09:30:02.576Z</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>89fd4eac-f4d2-4637-a601-118faebcaa28</td>\n",
+       "      <td>v2-e2e-test-space</td>\n",
+       "      <td>2024-07-11T06:18:12.508Z</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>fb8bd9cb-09d2-4ce9-b6ed-153076b30562</td>\n",
+       "      <td>GCR_prod</td>\n",
+       "      <td>2024-07-09T15:33:53.617Z</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>43854078-1c88-4ba9-904c-a805a4d18469</td>\n",
+       "      <td>GCRSpace</td>\n",
+       "      <td>2024-07-09T15:32:03.736Z</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>5ba115ac-70b9-455a-ba79-96d2912e4e12</td>\n",
+       "      <td>iris</td>\n",
+       "      <td>2024-07-05T15:39:08.106Z</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>523c8856-6d1e-49aa-b371-5dab42cd322c</td>\n",
+       "      <td>sdk-test-space</td>\n",
+       "      <td>2024-06-27T09:19:53.318Z</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 7
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:25.731065Z",
+     "start_time": "2024-09-18T10:59:25.728691Z"
+    }
+   },
+   "source": "existing_space_id = \"<EDIT THIS>\" # YOUR_SPACE_ID",
    "outputs": [],
-   "source": [
-    "existing_space_id = \"<EDIT THIS>\" # YOUR_SPACE_ID"
-   ]
+   "execution_count": 8
   },
   {
    "cell_type": "markdown",
@@ -271,12 +421,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:26.090641Z",
+     "start_time": "2024-09-18T10:59:26.088755Z"
+    }
+   },
+   "source": "space_name = \"<EDIT THIS>\" # YOUR_SPACE_NAME",
    "outputs": [],
-   "source": [
-    "space_name = \"<EDIT THIS>\" # YOUR_SPACE_NAME"
-   ]
+   "execution_count": 9
   },
   {
    "cell_type": "markdown",
@@ -287,16 +440,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:27.262760Z",
+     "start_time": "2024-09-18T10:59:27.260427Z"
+    }
+   },
    "source": [
     "#####################################################################################\n",
     "# Paste your WML_INSTANCE_NAME, WML CRN in the following field and then run this cell.\n",
     "######################################################################################\n",
     "WML_INSTANCE_NAME =  \"<EDIT THIS>\" # YOUR_WML_INSTANCE_NAME\n",
     "WML_CRN =  \"<EDIT THIS>\" # YOUR_WML_CRN"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 10
   },
   {
    "cell_type": "markdown",
@@ -308,12 +466,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T10:59:29.476815Z",
+     "start_time": "2024-09-18T10:59:29.474926Z"
+    }
+   },
+   "source": "COS_RESOURCE_CRN = \"<EDIT THIS>\"",
    "outputs": [],
-   "source": [
-    "COS_RESOURCE_CRN = \"<EDIT THIS>\""
-   ]
+   "execution_count": 11
   },
   {
    "cell_type": "markdown",
@@ -324,31 +485,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:00:37.947208Z",
+     "start_time": "2024-09-18T11:00:37.384573Z"
+    }
+   },
    "source": [
     "if use_existing_space == True:\n",
     "    space_id = existing_space_id\n",
     "else:\n",
     "    if use_cpd:\n",
     "        space_meta_data = {\n",
-    "            wml_client.spaces.ConfigurationMetaNames.NAME : space_name,\n",
-    "            wml_client.spaces.ConfigurationMetaNames.DESCRIPTION : 'tutorial_space'\n",
+    "            wx_ai_client.spaces.ConfigurationMetaNames.NAME : space_name,\n",
+    "            wx_ai_client.spaces.ConfigurationMetaNames.DESCRIPTION : 'tutorial_space'\n",
     "        }\n",
     "    else:\n",
     "        space_meta_data = {\n",
-    "            wml_client.spaces.ConfigurationMetaNames.NAME: space_name,\n",
-    "            wml_client.spaces.ConfigurationMetaNames.STORAGE: {\"resource_crn\":COS_RESOURCE_CRN},\n",
-    "            wml_client.spaces.ConfigurationMetaNames.COMPUTE: {\"name\": WML_INSTANCE_NAME, \"crn\": WML_CRN},\n",
-    "            wml_client.spaces.ConfigurationMetaNames.TYPE: \"wx\"\n",
+    "            wx_ai_client.spaces.ConfigurationMetaNames.NAME: space_name,\n",
+    "            wx_ai_client.spaces.ConfigurationMetaNames.STORAGE: {\"resource_crn\":COS_RESOURCE_CRN},\n",
+    "            wx_ai_client.spaces.ConfigurationMetaNames.COMPUTE: {\"name\": WML_INSTANCE_NAME, \"crn\": WML_CRN},\n",
+    "            wx_ai_client.spaces.ConfigurationMetaNames.TYPE: \"wx\"\n",
     "        }\n",
     "\n",
-    "    space_id = wml_client.spaces.store(\n",
+    "    space_id = wx_ai_client.spaces.store(\n",
     "        meta_props=space_meta_data)[\"metadata\"][\"id\"]\n",
-    "wml_client.set.default_space(space_id)\n",
+    "wx_ai_client.set.default_space(space_id)\n",
     "print(space_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bc592530-1cf0-4e56-9fab-70e0924f6907\n"
+     ]
+    }
+   ],
+   "execution_count": 12
   },
   {
    "cell_type": "markdown",
@@ -366,9 +540,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:30:56.933107Z",
+     "start_time": "2024-09-18T13:30:56.540076Z"
+    }
+   },
    "source": [
     "import requests, json\n",
     "def generate_access_token():\n",
@@ -400,7 +577,9 @@
     "    return iam_access_token\n",
     "\n",
     "iam_access_token = generate_access_token()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 13
   },
   {
    "cell_type": "markdown",
@@ -418,9 +597,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:00:43.806591Z",
+     "start_time": "2024-09-18T11:00:43.804126Z"
+    }
+   },
    "source": [
     "if not use_cpd:\n",
     "    credentials={\n",
@@ -435,16 +617,21 @@
     "#     \"instance_id\": \"openshift\",\n",
     "#     \"username\": WML_CREDENTIALS[\"username\"]\n",
     "# }"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 14
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:00:49.856480Z",
+     "start_time": "2024-09-18T11:00:44.687107Z"
+    }
+   },
    "source": [
-    "from ibm_watson_machine_learning.foundation_models.prompts import PromptTemplate, PromptTemplateManager\n",
-    "from ibm_watson_machine_learning.foundation_models.utils.enums import ModelTypes\n",
+    "from ibm_watsonx_ai.foundation_models.prompts import PromptTemplate, PromptTemplateManager\n",
+    "from ibm_watsonx_ai.foundation_models.utils.enums import ModelTypes\n",
     "\n",
     "prompt_mgr = PromptTemplateManager(\n",
     "                credentials = credentials,\n",
@@ -462,7 +649,20 @@
     "stored_prompt_template = prompt_mgr.store_prompt(prompt_template)\n",
     "project_pta_id = stored_prompt_template.prompt_id\n",
     "project_pta_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'e78d036b-a8dc-4989-80b5-d17073df6ec5'"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 15
   },
   {
    "cell_type": "markdown",
@@ -480,9 +680,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:25:52.734723Z",
+     "start_time": "2024-09-18T13:25:45.842794Z"
+    }
+   },
    "source": [
     "from ibm_cloud_sdk_core.authenticators import IAMAuthenticator, CloudPakForDataAuthenticator\n",
     "\n",
@@ -505,7 +708,17 @@
     "    authenticator = IAMAuthenticator(apikey=CLOUD_API_KEY, url = IAM_URL)\n",
     "    wos_client = APIClient(authenticator=authenticator, service_url = SERVICE_URL, service_instance_id = service_instance_id)\n",
     "    print(wos_client.version)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.0.40\n"
+     ]
+    }
+   ],
+   "execution_count": 16
   },
   {
    "cell_type": "markdown",
@@ -516,21 +729,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:00:58.458977Z",
+     "start_time": "2024-09-18T11:00:57.514271Z"
+    }
+   },
    "source": [
     "wos_client.data_marts.show()"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>Data Marts</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>name</th><th style='border: 1px solid #dddddd'>description</th><th style='border: 1px solid #dddddd'>internal_database</th><th style='border: 1px solid #dddddd'>status</th><th style='border: 1px solid #dddddd'>created_at</th><th style='border: 1px solid #dddddd'>id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>True</td><td style='border: 1px solid #dddddd'>active</td><td style='border: 1px solid #dddddd'>2024-08-07 17:06:38.901000+00:00</td><td style='border: 1px solid #dddddd'>58f9d73b-e4c6-43a8-8dc1-cbab5166ee0e</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 17
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:49:09.851881Z",
+     "start_time": "2024-09-18T13:49:09.849591Z"
+    }
+   },
+   "source": "data_mart_id = \"<EDIT THIS>\" # YOUR_DATAMART_ID",
    "outputs": [],
-   "source": [
-    "data_mart_id = \"<EDIT_THIS>\" # YOUR_DATAMART_ID"
-   ]
+   "execution_count": 18
   },
   {
    "cell_type": "markdown",
@@ -548,9 +790,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:01:01.962847Z",
+     "start_time": "2024-09-18T11:01:01.960467Z"
+    }
+   },
    "source": [
     "if use_cpd:\n",
     "    wos_client.wos.add_instance_mapping(                \n",
@@ -561,7 +806,9 @@
     "                    service_instance_id=data_mart_id,\n",
     "                    space_id=space_id\n",
     "                 )"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 19
   },
   {
    "cell_type": "markdown",
@@ -593,9 +840,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:01:43.312027Z",
+     "start_time": "2024-09-18T11:01:26.537688Z"
+    }
+   },
    "source": [
     "label_column = \"reference_summary\"\n",
     "operational_space_id = \"development\"\n",
@@ -614,7 +864,7 @@
     "    }\n",
     "}\n",
     "\n",
-    "response = wos_client.monitor_instances.mrm.execute_prompt_setup(prompt_template_asset_id = project_pta_id, \n",
+    "response = wos_client.wos.execute_prompt_setup(prompt_template_asset_id = project_pta_id, \n",
     "                                                                   project_id = project_id,\n",
     "                                                                   label_column = label_column, \n",
     "                                                                   operational_space_id = operational_space_id, \n",
@@ -625,7 +875,52 @@
     "\n",
     "result = response.result\n",
     "result._to_dict()"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "=============================================================================\n",
+      "\n",
+      " Waiting for end of adding prompt setup e78d036b-a8dc-4989-80b5-d17073df6ec5 \n",
+      "\n",
+      "=============================================================================\n",
+      "\n",
+      "\n",
+      "\n",
+      "running\n",
+      "finished\n",
+      "\n",
+      "---------------------------------------------------------------\n",
+      " Successfully finished setting up prompt template subscription \n",
+      "---------------------------------------------------------------\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'prompt_template_asset_id': 'e78d036b-a8dc-4989-80b5-d17073df6ec5',\n",
+       " 'project_id': '05add4b4-4c47-47c4-a6b6-e6b925ee748c',\n",
+       " 'deployment_id': '798f4e70-c15f-463a-b08d-9768940746ad',\n",
+       " 'service_provider_id': 'e11b28c4-d52e-49ac-96c0-1177fa194cc9',\n",
+       " 'subscription_id': '05dfdfa8-ebcb-42cb-ae38-254987ddbf44',\n",
+       " 'mrm_monitor_instance_id': '9e6b929d-6f39-4e85-9f7b-81970ae206f8',\n",
+       " 'start_time': '2024-09-18T11:01:28.980198Z',\n",
+       " 'end_time': '2024-09-18T11:01:35.449094Z',\n",
+       " 'status': {'state': 'FINISHED'}}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 20
   },
   {
    "cell_type": "markdown",
@@ -636,11 +931,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:01:53.446541Z",
+     "start_time": "2024-09-18T11:01:52.004315Z"
+    }
+   },
    "source": [
-    "response = wos_client.monitor_instances.mrm.get_prompt_setup(prompt_template_asset_id = project_pta_id,\n",
+    "response = wos_client.wos.get_prompt_setup(prompt_template_asset_id = project_pta_id,\n",
     "                                                             project_id = project_id)\n",
     "\n",
     "result = response.result\n",
@@ -650,7 +948,17 @@
     "    print(\"Finished prompt setup : The response is {}\".format(result_json))\n",
     "else:\n",
     "    print(\"prompt setup failed The response is {}\".format(result_json))"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished prompt setup : The response is {'prompt_template_asset_id': 'e78d036b-a8dc-4989-80b5-d17073df6ec5', 'project_id': '05add4b4-4c47-47c4-a6b6-e6b925ee748c', 'deployment_id': '798f4e70-c15f-463a-b08d-9768940746ad', 'service_provider_id': 'e11b28c4-d52e-49ac-96c0-1177fa194cc9', 'subscription_id': '05dfdfa8-ebcb-42cb-ae38-254987ddbf44', 'mrm_monitor_instance_id': '9e6b929d-6f39-4e85-9f7b-81970ae206f8', 'start_time': '2024-09-18T11:01:28.980198Z', 'end_time': '2024-09-18T11:01:35.449094Z', 'status': {'state': 'FINISHED'}}\n"
+     ]
+    }
+   ],
+   "execution_count": 21
   },
   {
    "cell_type": "markdown",
@@ -668,13 +976,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:01:56.338528Z",
+     "start_time": "2024-09-18T11:01:56.335369Z"
+    }
+   },
    "source": [
     "dev_subscription_id = result_json[\"subscription_id\"]\n",
     "dev_subscription_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'05dfdfa8-ebcb-42cb-ae38-254987ddbf44'"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 22
   },
   {
    "cell_type": "markdown",
@@ -686,12 +1010,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:02:00.104799Z",
+     "start_time": "2024-09-18T11:01:58.664994Z"
+    }
+   },
    "source": [
     "wos_client.monitor_instances.show(target_target_id = dev_subscription_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>Monitor instances</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>data_mart_id</th><th style='border: 1px solid #dddddd'>status</th><th style='border: 1px solid #dddddd'>target_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>created_at</th><th style='border: 1px solid #dddddd'>id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>58f9d73b-e4c6-43a8-8dc1-cbab5166ee0e</td><td style='border: 1px solid #dddddd'>active</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>2024-09-18 11:01:18.800000+00:00</td><td style='border: 1px solid #dddddd'>9e6b929d-6f39-4e85-9f7b-81970ae206f8</td></tr><tr><td style='border: 1px solid #dddddd'>58f9d73b-e4c6-43a8-8dc1-cbab5166ee0e</td><td style='border: 1px solid #dddddd'>active</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>2024-09-18 11:01:17.115000+00:00</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td></tr><tr><td style='border: 1px solid #dddddd'>58f9d73b-e4c6-43a8-8dc1-cbab5166ee0e</td><td style='border: 1px solid #dddddd'>active</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>2024-09-18 11:01:17.867000+00:00</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 23
   },
   {
    "cell_type": "markdown",
@@ -714,22 +1064,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:02:03.506631Z",
+     "start_time": "2024-09-18T11:02:02.498347Z"
+    }
+   },
    "source": [
     "# Download summarisation data\n",
     "!rm summarisation.csv\n",
     "!wget https://raw.githubusercontent.com/IBM/watson-openscale-samples/main/IBM%20Cloud/WML/assets/data/summarization/summarisation.csv"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--2024-09-18 16:32:02--  https://raw.githubusercontent.com/IBM/watson-openscale-samples/main/IBM%20Cloud/WML/assets/data/summarization/summarisation.csv\r\n",
+      "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.109.133, 185.199.110.133, 185.199.108.133, ...\r\n",
+      "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.109.133|:443... connected.\r\n",
+      "HTTP request sent, awaiting response... 200 OK\r\n",
+      "Length: 27115 (26K) [text/plain]\r\n",
+      "Saving to: ‘summarisation.csv’\r\n",
+      "\r\n",
+      "summarisation.csv   100%[===================>]  26.48K  --.-KB/s    in 0.01s   \r\n",
+      "\r\n",
+      "2024-09-18 16:32:03 (2.33 MB/s) - ‘summarisation.csv’ saved [27115/27115]\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "execution_count": 24
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:31:25.722650Z",
+     "start_time": "2024-09-18T13:31:25.720176Z"
+    }
+   },
    "source": [
-    "test_data_path = \"summarisation.csv\"\n",
+    "test_data_path = \"summarisation1.csv\"\n",
     "body = None # Please update your mapping file path here if needed\n",
     "\n",
     "# Download feedback data from project to local directory\n",
@@ -745,7 +1121,9 @@
     "# wslib.download_file(test_data_path)\n",
     "# if body:\n",
     "#     wslib.download_file(body)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 25
   },
   {
    "cell_type": "markdown",
@@ -758,9 +1136,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:02:05.724377Z",
+     "start_time": "2024-09-18T11:02:04.086539Z"
+    }
+   },
    "source": [
     "monitor_definition_id = \"mrm\"\n",
     "target_target_id = dev_subscription_id\n",
@@ -771,7 +1152,20 @@
     "result_json = result._to_dict()\n",
     "mrm_monitor_id = result_json[\"monitor_instances\"][0][\"metadata\"][\"id\"]\n",
     "mrm_monitor_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'9e6b929d-6f39-4e85-9f7b-81970ae206f8'"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 26
   },
   {
    "cell_type": "markdown",
@@ -782,9 +1176,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:05:33.470550Z",
+     "start_time": "2024-09-18T11:02:09.950641Z"
+    }
+   },
    "source": [
     "test_data_set_name = \"data\"\n",
     "content_type = \"multipart/form-data\"\n",
@@ -796,7 +1193,35 @@
     "                                                    body = body,\n",
     "                                                    project_id = project_id,\n",
     "                                                    background_mode = False)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "=================================================================================\n",
+      "\n",
+      " Waiting for risk evaluation of MRM monitor 9e6b929d-6f39-4e85-9f7b-81970ae206f8 \n",
+      "\n",
+      "=================================================================================\n",
+      "\n",
+      "\n",
+      "\n",
+      "upload_in_progress.....................\n",
+      "running...\n",
+      "finished\n",
+      "\n",
+      "---------------------------------------\n",
+      " Successfully finished evaluating risk \n",
+      "---------------------------------------\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 27
   },
   {
    "cell_type": "markdown",
@@ -809,13 +1234,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:05:36.235641Z",
+     "start_time": "2024-09-18T11:05:33.472484Z"
+    }
+   },
    "source": [
     "response  = wos_client.monitor_instances.mrm.get_risk_evaluation(mrm_monitor_id, project_id = project_id)\n",
     "response.result.to_dict()"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'metadata': {'id': 'cb233e2d-0aa0-4212-9a1d-f0d0fb0ae4e8',\n",
+       "  'created_at': '2024-09-18T11:04:53.216Z',\n",
+       "  'created_by': 'iam-ServiceId-b317a8da-d926-496e-b0ca-6bcc57f556ae'},\n",
+       " 'entity': {'triggered_by': 'user',\n",
+       "  'parameters': {'evaluation_start_time': '2024-09-18T11:02:14.220455Z',\n",
+       "   'evaluator_user_key': '8554ca34-75aa-4eb2-a546-00e8aadb541b',\n",
+       "   'facts': {'state': 'finished'},\n",
+       "   'is_auto_evaluated': False,\n",
+       "   'measurement_id': 'b3166e9f-50b4-45bc-8fd1-c27cac4e9286',\n",
+       "   'project_id': '05add4b4-4c47-47c4-a6b6-e6b925ee748c',\n",
+       "   'prompt_template_asset_id': 'e78d036b-a8dc-4989-80b5-d17073df6ec5',\n",
+       "   'user_iam_id': 'IBMid-692000BLQ0',\n",
+       "   'wos_created_deployment_id': '798f4e70-c15f-463a-b08d-9768940746ad',\n",
+       "   'publish_metrics': 'false',\n",
+       "   'evaluation_tests': ['drift_v2',\n",
+       "    'fairness',\n",
+       "    'generative_ai_quality',\n",
+       "    'model_health',\n",
+       "    'quality']},\n",
+       "  'status': {'state': 'finished',\n",
+       "   'queued_at': '2024-09-18T11:04:53.202000Z',\n",
+       "   'started_at': '2024-09-18T11:04:53.906000Z',\n",
+       "   'updated_at': '2024-09-18T11:05:30.250000Z',\n",
+       "   'completed_at': '2024-09-18T11:05:25.495000Z',\n",
+       "   'message': 'Mrm evaluation complete.',\n",
+       "   'operators': []}}}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 28
   },
   {
    "cell_type": "markdown",
@@ -828,12 +1294,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:05:41.854613Z",
+     "start_time": "2024-09-18T11:05:38.093326Z"
+    }
+   },
    "source": [
     "wos_client.monitor_instances.show_metrics(monitor_instance_id=mrm_monitor_id, project_id=project_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>9e6b929d-6f39-4e85-9f7b-81970ae206f8 Monitor Runs Metrics from: 2024-09-11 16:35:38.094139  till: 2024-09-18 16:35:38.094145</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>ts</th><th style='border: 1px solid #dddddd'>id</th><th style='border: 1px solid #dddddd'>measurement_id</th><th style='border: 1px solid #dddddd'>value</th><th style='border: 1px solid #dddddd'>lower_limit</th><th style='border: 1px solid #dddddd'>upper_limit</th><th style='border: 1px solid #dddddd'>tags</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>monitor_instance_id</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>target_id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:53.285000+00:00</td><td style='border: 1px solid #dddddd'>tests_passed</td><td style='border: 1px solid #dddddd'>b3166e9f-50b4-45bc-8fd1-c27cac4e9286</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['test_data_set_name:data']</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>9e6b929d-6f39-4e85-9f7b-81970ae206f8</td><td style='border: 1px solid #dddddd'>cb233e2d-0aa0-4212-9a1d-f0d0fb0ae4e8</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:53.285000+00:00</td><td style='border: 1px solid #dddddd'>tests_run</td><td style='border: 1px solid #dddddd'>b3166e9f-50b4-45bc-8fd1-c27cac4e9286</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['test_data_set_name:data']</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>9e6b929d-6f39-4e85-9f7b-81970ae206f8</td><td style='border: 1px solid #dddddd'>cb233e2d-0aa0-4212-9a1d-f0d0fb0ae4e8</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:53.285000+00:00</td><td style='border: 1px solid #dddddd'>tests_skipped</td><td style='border: 1px solid #dddddd'>b3166e9f-50b4-45bc-8fd1-c27cac4e9286</td><td style='border: 1px solid #dddddd'>3.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['test_data_set_name:data']</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>9e6b929d-6f39-4e85-9f7b-81970ae206f8</td><td style='border: 1px solid #dddddd'>cb233e2d-0aa0-4212-9a1d-f0d0fb0ae4e8</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:53.285000+00:00</td><td style='border: 1px solid #dddddd'>tests_failed</td><td style='border: 1px solid #dddddd'>b3166e9f-50b4-45bc-8fd1-c27cac4e9286</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['test_data_set_name:data']</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>9e6b929d-6f39-4e85-9f7b-81970ae206f8</td><td style='border: 1px solid #dddddd'>cb233e2d-0aa0-4212-9a1d-f0d0fb0ae4e8</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 29
   },
   {
    "cell_type": "markdown",
@@ -853,9 +1345,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:05:48.712708Z",
+     "start_time": "2024-09-18T11:05:47.910873Z"
+    }
+   },
    "source": [
     "monitor_definition_id = \"generative_ai_quality\"\n",
     "result = wos_client.monitor_instances.list(data_mart_id = data_mart_id,\n",
@@ -865,7 +1360,20 @@
     "result_json = result._to_dict()\n",
     "genaiquality_monitor_id = result_json[\"monitor_instances\"][0][\"metadata\"][\"id\"]\n",
     "genaiquality_monitor_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'de72ff19-f9aa-451d-bc22-5a277ca322f9'"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 30
   },
   {
    "cell_type": "markdown",
@@ -876,12 +1384,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:05:55.729009Z",
+     "start_time": "2024-09-18T11:05:51.261351Z"
+    }
+   },
    "source": [
     "wos_client.monitor_instances.show_metrics(monitor_instance_id=genaiquality_monitor_id, project_id=project_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>de72ff19-f9aa-451d-bc22-5a277ca322f9 Monitor Runs Metrics from: 2024-09-11 16:35:51.262389  till: 2024-09-18 16:35:51.262396</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>ts</th><th style='border: 1px solid #dddddd'>id</th><th style='border: 1px solid #dddddd'>measurement_id</th><th style='border: 1px solid #dddddd'>value</th><th style='border: 1px solid #dddddd'>lower_limit</th><th style='border: 1px solid #dddddd'>upper_limit</th><th style='border: 1px solid #dddddd'>tags</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>monitor_instance_id</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>target_id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>flesch_reading_ease</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>48.973</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>normalized_recall</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>0.0474</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>rouge2</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>0.024</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>records_processed</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>10.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>jaccard_similarity</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>0.037</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>meteor</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>0.0328</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>rougelsum</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>0.0814</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>normalized_precision</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>0.3119</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>bleu</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>0.0001</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:05:11.433040+00:00</td><td style='border: 1px solid #dddddd'>normalized_f1</td><td style='border: 1px solid #dddddd'>57e5467f-5163-470f-913d-150553289327</td><td style='border: 1px solid #dddddd'>0.0813</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>de72ff19-f9aa-451d-bc22-5a277ca322f9</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: First 10 records were displayed.\n"
+     ]
+    }
+   ],
+   "execution_count": 31
   },
   {
    "cell_type": "markdown",
@@ -899,9 +1440,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:05:57.896369Z",
+     "start_time": "2024-09-18T11:05:57.019843Z"
+    }
+   },
    "source": [
     "result = wos_client.data_sets.list(target_target_id = dev_subscription_id,\n",
     "                                target_target_type = \"subscription\",\n",
@@ -909,7 +1453,20 @@
     "\n",
     "genaiq_dataset_id = result.data_sets[0].metadata.id\n",
     "genaiq_dataset_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'d8c09f9a-e52c-4387-ac0e-b49cd81b9546'"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 32
   },
   {
    "cell_type": "markdown",
@@ -920,12 +1477,122 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:00.102563Z",
+     "start_time": "2024-09-18T11:05:58.483367Z"
+    }
+   },
+   "source": "wos_client.data_sets.show_records(data_set_id = genaiq_dataset_id)",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>Data Set d8c09f9a-e52c-4387-ac0e-b49cd81b9546 Records</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>flesch_reading_ease</th><th style='border: 1px solid #dddddd'>normalized_recall</th><th style='border: 1px solid #dddddd'>hap_input_score</th><th style='border: 1px solid #dddddd'>rouge2</th><th style='border: 1px solid #dddddd'>pii_entities</th><th style='border: 1px solid #dddddd'>scoring_id</th><th style='border: 1px solid #dddddd'>jaccard_similarity</th><th style='border: 1px solid #dddddd'>computed_on</th><th style='border: 1px solid #dddddd'>scoring_timestamp</th><th style='border: 1px solid #dddddd'>meteor</th><th style='border: 1px solid #dddddd'>rougelsum</th><th style='border: 1px solid #dddddd'>hap_score</th><th style='border: 1px solid #dddddd'>pii_input_entities</th><th style='border: 1px solid #dddddd'>pii</th><th style='border: 1px solid #dddddd'>normalized_precision</th><th style='border: 1px solid #dddddd'>hap_input_score_entities</th><th style='border: 1px solid #dddddd'>hap_score_positions</th><th style='border: 1px solid #dddddd'>bleu</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>normalized_f1</th><th style='border: 1px solid #dddddd'>pii_input_positions</th><th style='border: 1px solid #dddddd'>pii_positions</th><th style='border: 1px solid #dddddd'>rougel</th><th style='border: 1px solid #dddddd'>sari</th><th style='border: 1px solid #dddddd'>cosine_similarity</th><th style='border: 1px solid #dddddd'>hap_score_entities</th><th style='border: 1px solid #dddddd'>pii_input</th><th style='border: 1px solid #dddddd'>hap_input_score_positions</th><th style='border: 1px solid #dddddd'>rouge1</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>118.18</td><td style='border: 1px solid #dddddd'>0.17391304347826086</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.24</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-0</td><td style='border: 1px solid #dddddd'>0.14285714285714285</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.17330786026200873</td><td style='border: 1px solid #dddddd'>0.2963</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.005247518399181385</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.29629629629629634</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.2963</td><td style='border: 1px solid #dddddd'>55.38857182636525</td><td style='border: 1px solid #dddddd'>0.2554784079081934</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.2963</td></tr><tr><td style='border: 1px solid #dddddd'>59.97</td><td style='border: 1px solid #dddddd'>0.02564102564102564</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-1</td><td style='border: 1px solid #dddddd'>0.02857142857142857</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.013123359580052493</td><td style='border: 1px solid #dddddd'>0.0488</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.5</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.048780487804878044</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0488</td><td style='border: 1px solid #dddddd'>41.54530956428735</td><td style='border: 1px solid #dddddd'>0.03892030352151266</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0488</td></tr><tr><td style='border: 1px solid #dddddd'>120.21</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-2</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>58.22730947160862</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td></tr><tr><td style='border: 1px solid #dddddd'>36.62</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-3</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>49.80506188720799</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td></tr><tr><td style='border: 1px solid #dddddd'>59.97</td><td style='border: 1px solid #dddddd'>0.0625</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-4</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.030303030303030304</td><td style='border: 1px solid #dddddd'>0.1053</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.3333333333333333</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.10526315789473684</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1053</td><td style='border: 1px solid #dddddd'>34.44215049903712</td><td style='border: 1px solid #dddddd'>0.07240380080811218</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1053</td></tr><tr><td style='border: 1px solid #dddddd'>77.91</td><td style='border: 1px solid #dddddd'>0.07142857142857142</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-5</td><td style='border: 1px solid #dddddd'>0.0625</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.03048780487804878</td><td style='border: 1px solid #dddddd'>0.125</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.5</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.125</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.125</td><td style='border: 1px solid #dddddd'>51.48144633916992</td><td style='border: 1px solid #dddddd'>0.09588552733473388</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.125</td></tr><tr><td style='border: 1px solid #dddddd'>-51.03</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-6</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>32.31787167470213</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td></tr><tr><td style='border: 1px solid #dddddd'>38.99</td><td style='border: 1px solid #dddddd'>0.05714285714285714</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-7</td><td style='border: 1px solid #dddddd'>0.05263157894736842</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.03896103896103896</td><td style='border: 1px solid #dddddd'>0.0952</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.2857142857142857</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.09523809523809522</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0952</td><td style='border: 1px solid #dddddd'>34.246800192471554</td><td style='border: 1px solid #dddddd'>0.06256933485459629</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0952</td></tr><tr><td style='border: 1px solid #dddddd'>-6.7</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-8</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>33.129013634903835</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td></tr><tr><td style='border: 1px solid #dddddd'>35.61</td><td style='border: 1px solid #dddddd'>0.08333333333333333</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>MRM_3984fb65-0e08-4cc6-bbb6-5eae5dff9598-9</td><td style='border: 1px solid #dddddd'>0.08333333333333333</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T11:04:42.225Z</td><td style='border: 1px solid #dddddd'>0.04201680672268908</td><td style='border: 1px solid #dddddd'>0.1429</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.5</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>6fb0ad73-3ca0-4b0b-b8f2-11426a404dc9</td><td style='border: 1px solid #dddddd'>0.14285714285714285</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1429</td><td style='border: 1px solid #dddddd'>51.60075329566855</td><td style='border: 1px solid #dddddd'>0.1083015604191158</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1429</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 33
+  },
+  {
    "metadata": {},
-   "outputs": [],
+   "cell_type": "markdown",
    "source": [
-    "wos_client.data_sets.show_records(data_set_id = genaiq_dataset_id)"
+    "## Display the model health metrics\n",
+    "### Read the model health monitor instance id\n",
+    "Monitor instance ID of model health metrics is required for reading its metrics."
    ]
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:02.649292Z",
+     "start_time": "2024-09-18T11:06:01.637215Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "monitor_definition_id = \"model_health\"\n",
+    "result = wos_client.monitor_instances.list(data_mart_id = data_mart_id,\n",
+    "                                           monitor_definition_id = monitor_definition_id,\n",
+    "                                           target_target_id = target_target_id,\n",
+    "                                           project_id = project_id).result\n",
+    "result_json = result._to_dict()\n",
+    "mhm_monitor_id = result_json[\"monitor_instances\"][0][\"metadata\"][\"id\"]\n",
+    "mhm_monitor_id"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'e50f5304-9cb2-4826-a5cd-cdc457c512c8'"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 34
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Displaying the monitor metrics of model health"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:10.835756Z",
+     "start_time": "2024-09-18T11:06:07.139110Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "wos_client.monitor_instances.show_metrics(monitor_instance_id=mhm_monitor_id, project_id=project_id)",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>e50f5304-9cb2-4826-a5cd-cdc457c512c8 Monitor Runs Metrics from: 2024-09-11 16:36:07.140155  till: 2024-09-18 16:36:07.140162</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>ts</th><th style='border: 1px solid #dddddd'>id</th><th style='border: 1px solid #dddddd'>measurement_id</th><th style='border: 1px solid #dddddd'>value</th><th style='border: 1px solid #dddddd'>lower_limit</th><th style='border: 1px solid #dddddd'>upper_limit</th><th style='border: 1px solid #dddddd'>tags</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>monitor_instance_id</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>target_id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>total_records</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>10.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>maximum_record_throughput</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>0.068</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>median_api_throughput</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>0.011</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>median_input_token_count</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>393.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>average_output_token_count</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>4.6</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>minimum_api_throughput</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>0.007</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>median_record_latency</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>94921.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>minimum_output_token_count</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>2.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>users</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 11:04:59.829845+00:00</td><td style='border: 1px solid #dddddd'>maximum_api_latency</td><td style='border: 1px solid #dddddd'>4db311c8-08a0-40d1-84c9-86e193280d96</td><td style='border: 1px solid #dddddd'>143702.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>e50f5304-9cb2-4826-a5cd-cdc457c512c8</td><td style='border: 1px solid #dddddd'>08cf0a35-cceb-4065-a4ae-1e2725897914</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>05dfdfa8-ebcb-42cb-ae38-254987ddbf44</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: First 10 records were displayed.\n"
+     ]
+    }
+   ],
+   "execution_count": 35
   },
   {
    "cell_type": "markdown",
@@ -936,9 +1603,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:14.068686Z",
+     "start_time": "2024-09-18T11:06:12.370256Z"
+    }
+   },
    "source": [
     "result = wos_client.data_sets.get_list_of_records(data_set_id = genaiq_dataset_id).result\n",
     "result[\"records\"]\n",
@@ -949,7 +1619,9 @@
     "    x.append(each[\"metadata\"][\"id\"][-5:]) # Reading only last 5 characters to fit in the display\n",
     "    y_rougel.append(each[\"entity\"][\"values\"][\"rougel\"])\n",
     "    y_rougelsum.append(each[\"entity\"][\"values\"][\"rougelsum\"])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 36
   },
   {
    "cell_type": "markdown",
@@ -960,9 +1632,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:16.236905Z",
+     "start_time": "2024-09-18T11:06:15.920927Z"
+    }
+   },
    "source": [
     "import matplotlib.pyplot as plt\n",
     "plt.scatter(x, y_rougel, marker='o')\n",
@@ -974,7 +1649,20 @@
     "\n",
     "# Display the graph\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAHHCAYAAABXx+fLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABReUlEQVR4nO3deVxU1f8/8NcMCgMICLIrsWvuhCSSe6Kgae4hlQsfW7SvmuFKLshHE9dS0ygtlzQTtU3NcEFpE8VAMtfQUDNZ3AAFBZ05vz/8MZ9GFmdgYBju6/l4zOPjnDn33POemQ/z6s6Ze2VCCAEiIiIiCZEbegJEREREtY0BiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiAxq3rx5kMlkhp6G0UtKSoJMJkNSUlKl/TZu3AiZTIZLly49cUwPDw+MGTNGL/MjqmsYgIiIiEhyGICIiCRk5MiRuHfvHtzd3Q09FSKDYgAiqocKCwsNPQWjJ4TAvXv3DD0NNX3Nx8TEBAqFgl87kuQxABEZudI1NGfOnMHLL78MW1tbdOnSBQDw8OFDzJ8/H97e3jAzM4OHhwfeffddFBcXa4whk8kwb968MmOXtwbk5MmT6N69O8zNzdGsWTMsWLAAGzZsKHddyQ8//ICuXbvC0tISVlZWeOGFF3D69Gmda5wwYQIaNWqEoqKiMo+Fh4fD2dkZSqUSAPDbb78hJCQE9vb2MDc3h6enJ/7zn/88cR8eHh7o378/9u3bh4CAAJibm+OTTz4BAOTl5WHy5Mlwc3ODmZkZfHx8sHjxYqhUKo0xVCoVVq5cibZt20KhUMDBwQGhoaH47bff1H20fU0qm8/Vq1cxaNAgWFpawtHREe+8806Z7StS3hogIQQWLFiAZs2awcLCAj179qzS60RkTBoYegJEpB/Dhw+Hr68vFi5cCCEEAOC1117Dpk2bMGzYMEyZMgXHjh1DbGwszp49i2+++Ubnffzzzz/o2bMnZDIZoqKiYGlpiU8//RRmZmZl+m7evBmjR49GSEgIFi9ejKKiIsTFxaFLly44ceIEPDw8tN5vWFgY1qxZg++//x7Dhw9XtxcVFWH37t0YM2YMTExMkJubiz59+sDBwQEzZ85E48aNcenSJXz99dda7ef8+fMIDw/Hm2++iddffx0tWrRAUVERunfvjn/++QdvvvkmnnrqKRw5cgRRUVHIysrCihUr1NuPHTsWGzduRN++ffHaa6/h4cOH+Pnnn3H06FEEBAQA0O01KW8+9+7dQ69evXDlyhVMmjQJrq6u2Lx5Mw4dOqT18/m4uXPnYsGCBejXrx/69euHtLQ09OnTByUlJVUek6jOE0Rk1KKjowUAER4ertGenp4uAIjXXntNo33q1KkCgDh06JC6DYCIjo4uM7a7u7sYPXq0+v7EiROFTCYTJ06cULfdvHlT2NnZCQAiMzNTCCHEnTt3ROPGjcXrr7+uMV52drawsbHRaC+df2VUKpVo2rSpGDp0qEb79u3bBQDx008/CSGE+OabbwQAcfz48UrHK4+7u7sAIBISEjTa58+fLywtLcWff/6p0T5z5kxhYmIirly5IoQQ4tChQwKAmDRpUrnzF0K316Si+axYsUIAENu3b1e3FRYWCh8fHwFAHD58uNI6N2zYoPFa5ebmClNTU/HCCy+o5ymEEO+++64AoPH6E9Un/AqMqJ4YN26cxv29e/cCACIjIzXap0yZAgD4/vvvdd5HQkICgoKC4Ofnp26zs7PDK6+8otHvwIEDyMvLQ3h4OG7cuKG+mZiYIDAwEIcPH9ZpvzKZDMOHD8fevXtx9+5ddXt8fDyaNm2q/sqvcePGAIA9e/bgwYMHOtfn6emJkJAQjbYdO3aga9eusLW11aglODgYSqUSP/30EwDgq6++gkwmQ3R0dLnzB3R/Tcqbz969e+Hi4oJhw4ap2ywsLPDGG2/oXC8AHDx4ECUlJZg4caLGuqDJkydXaTwiY8EARFRPeHp6aty/fPky5HI5fHx8NNqdnZ3RuHFjXL58Wed9XL58ucx4AMq0ZWRkAACef/55ODg4aNz279+P3NxcnfcdFhaGe/fuYdeuXQCAu3fvYu/evRg+fLj6g7t79+4YOnQoYmJiYG9vj4EDB2LDhg1ar495/DksrSUhIaFMHcHBwQCgruXixYtwdXWFnZ1dhePr+pqUN5/S1+DxRcwtWrTQqsbyxgMAX19fjXYHBwfY2tpWaUwiY8A1QET1hLm5ebnt1fm1T+nCYl2VLg7evHkznJ2dyzzeoIHuf3o6deoEDw8PbN++HS+//DJ2796Ne/fuISwsTN1HJpNh586dOHr0KHbv3o19+/bhP//5D5YvX46jR4+iUaNGle6jvOdQpVKhd+/emD59ernbNG/eXOdatH1NKnpNiaj6GICI6il3d3eoVCpkZGSgZcuW6vacnBzk5eVpnAfG1tYWeXl5GtuXlJQgKyurzJgXLlwos6/H27y9vQEAjo6O6iMl+vDSSy9h5cqVKCgoQHx8PDw8PNCpU6cy/Tp16oROnTrhvffew9atW/HKK69g27ZteO2113Tep7e3N+7evfvEOry9vbFv3z7cunWrwqNAurwmFXF3d8epU6cghNAIUufPn9eyorLjAY+OdHl5eanbr1+/jtu3b1dpTCJjwK/AiOqpfv36AYDGr5QA4P333wcAvPDCC+o2b29v9VqWUmvXri1zBCgkJATJyclIT09Xt926dQtffPFFmX7W1tZYuHBhuWtxrl+/rnM9wKOvwYqLi7Fp0yYkJCTgpZde0nj89u3b6l/AlSpdr6Tt12CPe+mll5CcnIx9+/aVeSwvLw8PHz4EAAwdOhRCCMTExJTpVzonXV6TivTr1w/Xrl3Dzp071W1FRUVYu3atdgU9Jjg4GA0bNsSHH36o8dw9Pkei+oZHgIjqqfbt22P06NFYu3Yt8vLy0L17d6SkpGDTpk0YNGgQevbsqe772muvYdy4cRg6dCh69+6N33//Hfv27YO9vb3GmNOnT8eWLVvQu3dvTJw4Uf0z+Keeegq3bt1SH5GwtrZGXFwcRo4cCX9/f4wYMQIODg64cuUKvv/+e3Tu3BmrV6/WuSZ/f3/4+Phg1qxZKC4u1vj6CwA2bdqEjz76CIMHD4a3tzfu3LmDdevWwdraWh0+dDVt2jTs2rUL/fv3x5gxY9ChQwcUFhbijz/+wM6dO3Hp0iXY29ujZ8+eGDlyJFatWoWMjAyEhoZCpVLh559/Rs+ePTFhwgSdXpOKvP7661i9ejVGjRqF1NRUuLi4YPPmzbCwsKhSfQ4ODpg6dSpiY2PRv39/9OvXDydOnMAPP/xQ5vUnqlcM+hs0Iqq20p+RX79+vcxjDx48EDExMcLT01M0bNhQuLm5iaioKHH//n2NfkqlUsyYMUPY29sLCwsLERISIi5cuFDmZ/BCCHHixAnRtWtXYWZmJpo1ayZiY2PFqlWrBACRnZ2t0ffw4cMiJCRE2NjYCIVCIby9vcWYMWPEb7/9Vmb+2po1a5YAIHx8fMo8lpaWJsLDw8VTTz0lzMzMhKOjo+jfv7/G/iri7u4uXnjhhXIfu3PnjoiKihI+Pj7C1NRU2Nvbi+eee04sW7ZMlJSUqPs9fPhQLF26VDz99NPC1NRUODg4iL59+4rU1FR1H21fk8rmc/nyZfHiiy8KCwsLYW9vL95++22RkJBQpZ/BC/Ho9Y+JiREuLi7C3Nxc9OjRQ5w6darc15+ovpAJ8djxYiIiHU2ePBmffPIJ7t69CxMTE0NPh4joibgGiIh08vj1qG7evInNmzejS5cuDD9EZDS4BoiIdBIUFIQePXqgZcuWyMnJwWeffYaCggLMmTPH0FMjItIaAxAR6aRfv37YuXMn1q5dC5lMBn9/f3z22Wfo1q2boadGRKQ1rgEiIiIiyeEaICIiIpIcBiAiIiKSHK4BKodKpcK1a9dgZWVVresoERERUe0RQuDOnTtwdXWFXF75MR4GoHJcu3YNbm5uhp4GERERVcHff/+NZs2aVdqHAagcVlZWAB49gdbW1gaeDREREWmjoKAAbm5u6s/xyjAAlePf1zNiACIiIjIu2ixf4SJoIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpKcOhGA1qxZAw8PDygUCgQGBiIlJaXCvl9//TUCAgLQuHFjWFpaws/PD5s3b9boI4TA3Llz4eLiAnNzcwQHByMjI6OmyyAiIiIjYfAAFB8fj8jISERHRyMtLQ3t27dHSEgIcnNzy+1vZ2eHWbNmITk5GSdPnkRERAQiIiKwb98+dZ8lS5Zg1apV+Pjjj3Hs2DFYWloiJCQE9+/fr62yiIiIqA4z+NXgAwMD8eyzz2L16tUAHl2Gws3NDRMnTsTMmTO1GsPf3x8vvPAC5s+fDyEEXF1dMWXKFEydOhUAkJ+fDycnJ2zcuBEjRox44ngFBQWwsbFBfn4+zwNERERkJHT5/DboEaCSkhKkpqYiODhY3SaXyxEcHIzk5OQnbi+EQGJiIs6fP49u3boBADIzM5Gdna0xpo2NDQIDA7Uak4iIiOo/g54J+saNG1AqlXByctJod3Jywrlz5yrcLj8/H02bNkVxcTFMTEzw0UcfoXfv3gCA7Oxs9RiPj1n62OOKi4tRXFysvl9QUFClep5EqRJIybyF3Dv34WilQEdPO5jIebFVIiKi2maUl8KwsrJCeno67t69i8TERERGRsLLyws9evSo0nixsbGIiYnR7yQfk3AqCzG7zyAr/3/rkFxsFIge0AqhbVxqdN9ERESkyaBfgdnb28PExAQ5OTka7Tk5OXB2dq5wO7lcDh8fH/j5+WHKlCkYNmwYYmNjAUC9nS5jRkVFIT8/X337+++/q1NWGQmnsjB+S5pG+AGA7Pz7GL8lDQmnsvS6PyIiIqqcQQOQqakpOnTogMTERHWbSqVCYmIigoKCtB5HpVKpv8Ly9PSEs7OzxpgFBQU4duxYhWOamZmpL3yq7wugKlUCMbvPoLyV5qVtMbvPQKky6Fp0IiIiSTH4V2CRkZEYPXo0AgIC0LFjR6xYsQKFhYWIiIgAAIwaNQpNmzZVH+GJjY1FQEAAvL29UVxcjL1792Lz5s2Ii4sD8OgKsJMnT8aCBQvg6+sLT09PzJkzB66urhg0aFCt15eSeavMkZ9/EwCy8u8jJfMWgryb1N7EiIiIJMzgASgsLAzXr1/H3LlzkZ2dDT8/PyQkJKgXMV+5cgVy+f8OVBUWFuKtt97C1atXYW5ujqeffhpbtmxBWFiYus/06dNRWFiIN954A3l5eejSpQsSEhKgUChqvb7cO9qde0jbfkRERFR9Bj8PUF2kz/MAJV+8ifB1R5/Y78vXO/EIEBERUTUYzXmApKCjpx1cbBSo6MfuMjz6NVhHT7vanBYREZGkMQDVMBO5DNEDWgFAmRBUej96QCueD4iIiKgWMQDVgtA2Loh71R/ONpprkJxtFIh71Z/nASIiIqplBl8ELRWhbVzQu5UzzwRNRERUBzAA1SITuYwLnYmIiOoAfgVGREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJJTJwLQmjVr4OHhAYVCgcDAQKSkpFTYd926dejatStsbW1ha2uL4ODgMv3HjBkDmUymcQsNDa3pMoiIiMhIGDwAxcfHIzIyEtHR0UhLS0P79u0REhKC3NzccvsnJSUhPDwchw8fRnJyMtzc3NCnTx/8888/Gv1CQ0ORlZWlvn355Ze1UQ4REREZAZkQQhhyAoGBgXj22WexevVqAIBKpYKbmxsmTpyImTNnPnF7pVIJW1tbrF69GqNGjQLw6AhQXl4evv322yrNqaCgADY2NsjPz4e1tXWVxiAiIqLapcvnt0GPAJWUlCA1NRXBwcHqNrlcjuDgYCQnJ2s1RlFRER48eAA7OzuN9qSkJDg6OqJFixYYP348bt68WeEYxcXFKCgo0LgRERFR/WXQAHTjxg0olUo4OTlptDs5OSE7O1urMWbMmAFXV1eNEBUaGorPP/8ciYmJWLx4MX788Uf07dsXSqWy3DFiY2NhY2Ojvrm5uVW9KCIiIqrzGhh6AtWxaNEibNu2DUlJSVAoFOr2ESNGqP/dtm1btGvXDt7e3khKSkKvXr3KjBMVFYXIyEj1/YKCAoYgIiKiesygR4Ds7e1hYmKCnJwcjfacnBw4OztXuu2yZcuwaNEi7N+/H+3atau0r5eXF+zt7XHhwoVyHzczM4O1tbXGjYiIiOovgwYgU1NTdOjQAYmJieo2lUqFxMREBAUFVbjdkiVLMH/+fCQkJCAgIOCJ+7l69Spu3rwJFxcXvcybiIiIjJvBfwYfGRmJdevWYdOmTTh79izGjx+PwsJCREREAABGjRqFqKgodf/Fixdjzpw5WL9+PTw8PJCdnY3s7GzcvXsXAHD37l1MmzYNR48exaVLl5CYmIiBAwfCx8cHISEhBqmRiIiI6haDrwEKCwvD9evXMXfuXGRnZ8PPzw8JCQnqhdFXrlyBXP6/nBYXF4eSkhIMGzZMY5zo6GjMmzcPJiYmOHnyJDZt2oS8vDy4urqiT58+mD9/PszMzGq1NiIiIqqbDH4eoLqI5wEiIiIyPkZzHiAiIiIiQ2AAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyakTAWjNmjXw8PCAQqFAYGAgUlJSKuy7bt06dO3aFba2trC1tUVwcHCZ/kIIzJ07Fy4uLjA3N0dwcDAyMjJqugwiIiIyEgYPQPHx8YiMjER0dDTS0tLQvn17hISEIDc3t9z+SUlJCA8Px+HDh5GcnAw3Nzf06dMH//zzj7rPkiVLsGrVKnz88cc4duwYLC0tERISgvv379dWWURERFSHyYQQwpATCAwMxLPPPovVq1cDAFQqFdzc3DBx4kTMnDnzidsrlUrY2tpi9erVGDVqFIQQcHV1xZQpUzB16lQAQH5+PpycnLBx40aMGDHiiWMWFBTAxsYG+fn5sLa2rl6BREREVCt0+fw26BGgkpISpKamIjg4WN0ml8sRHByM5ORkrcYoKirCgwcPYGdnBwDIzMxEdna2xpg2NjYIDAyscMzi4mIUFBRo3IiIiKj+MmgAunHjBpRKJZycnDTanZyckJ2drdUYM2bMgKurqzrwlG6ny5ixsbGwsbFR39zc3HQthYiIiIyIwdcAVceiRYuwbds2fPPNN1AoFFUeJyoqCvn5+erb33//rcdZEhERUV3TwJA7t7e3h4mJCXJycjTac3Jy4OzsXOm2y5Ytw6JFi3Dw4EG0a9dO3V66XU5ODlxcXDTG9PPzK3csMzMzmJmZVbEKIiIiMjYGPQJkamqKDh06IDExUd2mUqmQmJiIoKCgCrdbsmQJ5s+fj4SEBAQEBGg85unpCWdnZ40xCwoKcOzYsUrHJCIiIukw6BEgAIiMjMTo0aMREBCAjh07YsWKFSgsLERERAQAYNSoUWjatCliY2MBAIsXL8bcuXOxdetWeHh4qNf1NGrUCI0aNYJMJsPkyZOxYMEC+Pr6wtPTE3PmzIGrqysGDRpkqDKJiIioDtFbADp37hxefPFF/PnnnzptFxYWhuvXr2Pu3LnIzs6Gn58fEhIS1IuYr1y5Arn8fweq4uLiUFJSgmHDhmmMEx0djXnz5gEApk+fjsLCQrzxxhvIy8tDly5dkJCQUK11QkRERFR/6O08QL///jv8/f2hVCr1MZxB8TxARERExsdozgNEREREZAgMQERERCQ5DEBEREQkOVovgra1tYVMJqvw8YcPH+plQkREREQ1TesA9MEHH1QagIiIiIiMhdYBaMyYMTU4DSIiIqLao/UaoJSUlEp/4l5cXIzt27frZVJERERENUnrABQUFISbN2+q71tbW+Ovv/5S38/Ly0N4eLh+Z0dERERUA7QOQI+fL7G88yfq6ZyKRERERDVKrz+D5yJpIiIiMgY8DxARERFJjk4XQz1z5oz66utCCJw7dw53794FANy4cUP/syMiIiKqAVpfDFUul0Mmk5W7zqe0XSaT8WKoREREZBC6fH5rfQQoMzOz2hMjIiIiqgu0DkDu7u41OQ8iIiKiWqPTGqCCggL1IaW9e/dqXP/LxMQEL7zwgn5nR0RERFQDtA5Ae/bswZw5c3DixAkAQFhYGAoLC9WPy2QyxMfHY9iwYfqfJREREZEeaf0z+LVr12LixIkabRcuXIBKpYJKpUJsbCzWr1+v9wkSERER6ZvWAeiPP/5A586dK3y8b9+++O233/QyKSIiIqKapHUAysrKgpmZmfr+4cOH4ebmpr7fqFEj5Ofn63d2RERERDVA6wBkZ2eHCxcuqO8HBASgYcOG6vsZGRmws7PT7+yIiIiIaoDWAahbt25YtWpVhY+vWrUK3bp108ukiIiIiGqS1gFoxowZ2L9/P4YPH47jx48jPz8f+fn5SElJwdChQ3Hw4EHMmDGjJudKREREpBda/wz+mWeeQXx8PF577TV8/fXXGo/Z2tpi27Zt8Pf31/sEiYiIiPRN62uBlSoqKsK+ffuQkZEBAPD19UWfPn1gaWlZIxM0BF4LjIiIyPjUyLXASllYWGDw4MFVnhwRERGRoWkdgCIjI8ttt7GxQfPmzTFkyBCNn8kTERER1VVaB6DSS2A8Li8vDxcuXMCcOXNw6NAhPPXUU3qbHBEREVFN0HkNUHkKCgrwyiuvwMrKClu3btXHvAyKa4CIiIiMjy6f31r/DL4y1tbWmDNnDn799Vd9DEdERERUo/QSgADA3t4et27d0tdwRERERDVGbwHo6NGj8Pb21tdwRERERDVG60XQJ0+eLLc9Pz8fqampWLhwIaKjo/U2MSIiIqKaonUA8vPzg0wmQ3lrpu3t7REZGYm33npLr5MjIiIiqglaB6DMzMxy262trWFra6u3CRERERHVNK0DkLu7e03Og4iIiKjW6LwIeseOHRgyZAjatGmDNm3aYMiQIdi5c2dNzI2IiIioRmgdgFQqFcLCwhAWFoYzZ87Ax8cHPj4+OH36NMLCwjBixIhy1wcRERER1TVafwW2cuVKHDx4ELt27UL//v01Htu1axciIiKwcuVKTJ48Wd9zJCIiItIrrY8AbdiwAUuXLi0TfgDgxRdfxJIlS7B+/Xq9To6IiIioJmgdgDIyMhAcHFzh48HBwcjIyNDLpIiIiIhqktYByNzcHHl5eRU+XlBQAIVCoY85EREREdUorQNQUFAQ4uLiKnx8zZo1CAoK0sukiIiIiGqS1ougZ82ahR49euDmzZuYOnUqnn76aQghcPbsWSxfvhzfffcdDh8+XJNzJSIiItILrQPQc889h/j4eLzxxhv46quvNB6ztbXFl19+ic6dO+t9gkRERET6JhM6nrynqKgI+/btUy94bt68Ofr06QMLC4samaAhFBQUwMbGBvn5+bC2tjb0dIiIiEgLunx+63wmaAsLCwwePBjTp0/H9OnTMWjQIHX4+eeff3Se7Jo1a+Dh4QGFQoHAwECkpKRU2Pf06dMYOnQoPDw8IJPJsGLFijJ95s2bB5lMpnF7+umndZ4XERER1V86B6DyZGdnY+LEifD19dVpu/j4eERGRiI6OhppaWlo3749QkJCkJubW27/oqIieHl5YdGiRXB2dq5w3NatWyMrK0t9++WXX3SaFxEREdVvWgeg27dvIzw8HPb29nB1dcWqVaugUqkwd+5ceHl54fjx49iwYYNOO3///ffx+uuvIyIiAq1atcLHH38MCwuLCk+o+Oyzz2Lp0qUYMWIEzMzMKhy3QYMGcHZ2Vt/s7e11mhcRERHVb1ovgp45cyaOHDmCMWPGYN++fXjnnXeQkJAAuVyOQ4cOoVOnTjrtuKSkBKmpqYiKilK3yeVyBAcHIzk5WaexHpeRkQFXV1coFAoEBQUhNjYWTz31VIX9i4uLUVxcrL5fUFBQrf0TERFR3ab1EaAffvgBGzZswLJly7B7924IIeDn54c9e/boHH4A4MaNG1AqlXByctJod3JyQnZ2ts7jlQoMDMTGjRuRkJCAuLg4ZGZmomvXrrhz506F28TGxsLGxkZ9c3Nzq/L+iYiIqO7TOgBdu3YNLVu2BAD1ouVXX321xiZWVX379sXw4cPRrl07hISEYO/evcjLy8P27dsr3CYqKgr5+fnq299//12LMyYiIqLapvVXYEIINGjwv+4mJiYwNzev8o7t7e1hYmKCnJwcjfacnJxKFzjrqnHjxmjevDkuXLhQYR8zM7NK1xQRERFR/aJTAOrVq5c6BN27dw8DBgyAqampRr+0tDStxjM1NUWHDh2QmJiIQYMGAQBUKhUSExMxYcIEbaf1RHfv3sXFixcxcuRIvY1JREREulOqBFIybyH3zn04WinQ0dMOJnKZQeaidQCKjo7WuD9w4MBq7zwyMhKjR49GQEAAOnbsiBUrVqCwsBAREREAgFGjRqFp06aIjY0F8Gjh9JkzZ9T//ueff5Ceno5GjRrBx8cHADB16lQMGDAA7u7uuHbtGqKjo2FiYoLw8PBqz5eIiIiqJuFUFmJ2n0FW/n11m4uNAtEDWiG0jUutz0fnM0Hr2+rVq7F06VJkZ2fDz88Pq1atQmBgIACgR48e8PDwwMaNGwEAly5dgqenZ5kxunfvjqSkJADAiBEj8NNPP+HmzZtwcHBAly5d8N5778Hb21vrOfFM0ERERPqTcCoL47ek4fHAUXrsJ+5Vf72EIF0+vw0egOoiBiAiIiL9UKoEuiw+pHHk599kAJxtFPhlxvPV/jqsRi+FQURERKStlMxbFYYfABAAsvLvIyXzVu1NCgxAREREVINy71QcfqrST18YgIiIiKjGOFop9NpPX6oVgK5evQqVSqWvuRAREVE909HTDi42ClS0ukeGR78G6+hpV5vTql4AatWqFS5duqSnqRAREVF9YyKXIXpAKwAoE4JK70cPaFXr5wOqVgDiD8iIiIjoSULbuCDuVX8422h+zeVso9DbT+B1pfWJEImIiIiqKrSNC3q3cja+M0GX591334WdXe1+Z0dERETGyUQuQ5B3E0NPAwBPhFgungiRiIjI+PBEiERERESVYAAiIiIiyWEAIiIiIslhACIiIiLJ0TkAJSQk4JdfflHfX7NmDfz8/PDyyy/j9u3bep0cERERUU3QOQBNmzYNBQUFAIA//vgDU6ZMQb9+/ZCZmYnIyEi9T5CIiIhI33Q+D1BmZiZatXp0SuuvvvoK/fv3x8KFC5GWloZ+/frpfYJERERE+qZzADI1NUVRUREA4ODBgxg1ahQAwM7OTn1kiIhIqpQqUWfOdEtEFdM5AHXp0gWRkZHo3LkzUlJSEB8fDwD4888/0axZM71PkIjIWCScykLM7jPIyr+vbnOxUSB6QCuDXOuIiCqm8xqg1atXo0GDBti5cyfi4uLQtGlTAMAPP/yA0NBQvU+QiMgYJJzKwvgtaRrhBwCy8+9j/JY0JJzKMtDMiKg8vBRGOXgpDCLShVIl0GXxoTLhp5QMj656/cuM5/l1GFEN0uXzW6uvwAoKCtQDPWmdDwMDEUlNSuatCsMPAAgAWfn3kZJ5q85cCJJI6rQKQLa2tsjKyoKjoyMaN24Mmazsf8EIISCTyaBUKvU+SSKiuiz3TsXhpyr9iKjmaRWADh06BDs7O/W/ywtARERS5Wil0Gs/Iqp5WgWg7t27q//do0ePmpoLEZFR6uhpBxcbBbLz76O8RZWla4A6etrV9tSIqAI6/wps3rx5UKlUZdrz8/MRHh6ul0kRERkTE7kM0QMenSD28ePjpfejB7TiAmiiOkTnAPTZZ5+hS5cu+Ouvv9RtSUlJaNu2LS5evKjXyRERGYvQNi6Ie9UfzjaaX3M52ygQ96o/zwNEVMfofCLEkydP4s0334Sfnx+WL1+OP//8EytXrsS0adMQExNTE3MkIjIKoW1c0LuVM88ETWQEqnweoHfffReLFi1CgwYN8MMPP6BXr176npvB8DxARERExkeXz2+dvwIDgA8//BArV65EeHg4vLy8MGnSJPz+++9VmiwRERFRbdM5AIWGhiImJgabNm3CF198gRMnTqBbt27o1KkTlixZUhNzJCIiItIrnQOQUqnEyZMnMWzYMACAubk54uLisHPnTnzwwQd6nyARERGRvun1WmA3btyAvb29voYzGK4BIiIiMj41vgaoIvUh/BAREVH9p/PP4JVKJT744ANs374dV65cQUlJicbjt27d0tvkiIiIiGqCzkeAYmJi8P777yMsLAz5+fmIjIzEkCFDIJfLMW/evBqYIhEREZF+6RyAvvjiC6xbtw5TpkxBgwYNEB4ejk8//RRz587F0aNHa2KORERERHqlcwDKzs5G27ZtAQCNGjVCfn4+AKB///74/vvv9Ts7IiIiohqgcwBq1qwZsrKyAADe3t7Yv38/AOD48eMwMzPT7+yIiIiIaoDOAWjw4MFITEwEAEycOBFz5syBr68vRo0ahf/85z96nyARERGRvlX7PEDJyclITk6Gr68vBgwYoK95GRTPA0RU+5QqwYuIElG16PL5rfPP4B8XFBSEoKCg6g5DRBKWcCoLMbvPICv/vrrNxUaB6AGtENrGxYAzI6L6qlonQrS2tsZff/2lr7kQkQQlnMrC+C1pGuEHALLz72P8ljQknMoy0MyIqD7TOgBdu3atTJser6JBRBKkVAnE7D6D8v6SlLbF7D4DpYp/a4hIv7QOQK1bt8bWrVtrci5EJDEpmbfKHPn5NwEgK/8+UjJ5hnki0i+tA9B7772HN998E8OHD1df7uLVV1/lImEiqrLcOxWHn6r0IyLSltYB6K233sLJkydx8+ZNtGrVCrt370ZcXFy1L4C6Zs0aeHh4QKFQIDAwECkpKRX2PX36NIYOHQoPDw/IZDKsWLGi2mMSkeE4Win02o+ISFs6LYL29PTEoUOHMHv2bAwZMgTt2rWDv7+/xk0X8fHxiIyMRHR0NNLS0tC+fXuEhIQgNze33P5FRUXw8vLCokWL4OzsrJcxichwOnrawcVGgYp+7C7Do1+DdfS0q81pEZEE6HweoMuXLyMiIgKnTp3Cm2++iQYNNH9JHx0drfVYgYGBePbZZ7F69WoAgEqlgpubGyZOnIiZM2dWuq2HhwcmT56MyZMn623MUjwPEFHtKf0VGACNxdCloSjuVX/+FJ6ItFJj5wEqvQhqcHAwTp8+DQcHhypPsqSkBKmpqYiKilK3yeVyBAcHIzk5uc6MSUQ1K7SNC+Je9S9zHiBnngeIiGqQ1gEoNDQUKSkpWL16NUaNGlXtHd+4cQNKpRJOTk4a7U5OTjh37lytjllcXIzi4mL1/YKCgirtn4iqJrSNC3q3cuaZoImo1mgdgJRKJU6ePIlmzZrV5HwMIjY2FjExMYaeBpGkmchlCPJuYuhpUD3DS6xQRbQOQAcOHNDrju3t7WFiYoKcnByN9pycnAoXONfUmFFRUYiMjFTfLygogJubW5XmQEREdQMvsUKVqdalMKrD1NQUHTp0UF9ZHni0YDkxMbHK1xar6phmZmawtrbWuBERkfHiJVboSap9MdTqiIyMxOjRoxEQEICOHTtixYoVKCwsREREBABg1KhRaNq0KWJjYwE8WuR85swZ9b//+ecfpKeno1GjRvDx8dFqTCIiqt+edIkVGR5dYqV3K2d+HSZhBg1AYWFhuH79OubOnYvs7Gz4+fkhISFBvYj5ypUrkMv/d5Dq2rVreOaZZ9T3ly1bhmXLlqF79+5ISkrSakwiIqrfdLnECtedSZfO5wGSAp4HiIjIeH2X/g/e3pb+xH4rR/hhoF/Tmp8Q1RpdPr8NtgaIiIioJvASK6QNBiAiIqpXeIkV0gYDEBER1SsmchmiB7QCgDIhqPR+9IBWXAAtcQxARERU75ReYsXZRvNrLmcbBa8vRwAM/CswIiKimsJLrFBlGICIiKje4iVWqCL8CoyIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkp04EoDVr1sDDwwMKhQKBgYFISUmptP+OHTvw9NNPQ6FQoG3btti7d6/G42PGjIFMJtO4hYaG1mQJREREZEQMHoDi4+MRGRmJ6OhopKWloX379ggJCUFubm65/Y8cOYLw8HCMHTsWJ06cwKBBgzBo0CCcOnVKo19oaCiysrLUty+//LI2ypEEpUog+eJNfJf+D5Iv3oRSJQw9JSIiIp3IhBAG/fQKDAzEs88+i9WrVwMAVCoV3NzcMHHiRMycObNM/7CwMBQWFmLPnj3qtk6dOsHPzw8ff/wxgEdHgPLy8vDtt99WaU4FBQWwsbFBfn4+rK2tqzRGfZVwKgsxu88gK/++us3FRoHoAa0Q2sbFgDMjIiKp0+Xz26BHgEpKSpCamorg4GB1m1wuR3BwMJKTk8vdJjk5WaM/AISEhJTpn5SUBEdHR7Ro0QLjx4/HzZs3K5xHcXExCgoKNG5UVsKpLIzfkqYRfgAgO/8+xm9JQ8KpLAPNjIiISDcGDUA3btyAUqmEk5OTRruTkxOys7PL3SY7O/uJ/UNDQ/H5558jMTERixcvxo8//oi+fftCqVSWO2ZsbCxsbGzUNzc3t2pWVv8oVQIxu8+gvMOFpW0xu8/w6zAiIjIKDQw9gZowYsQI9b/btm2Ldu3awdvbG0lJSejVq1eZ/lFRUYiMjFTfLygoYAh6TErmrTJHfv5NAMjKv4+UzFsI8m5SexMjIiKqAoMeAbK3t4eJiQlycnI02nNycuDs7FzuNs7Ozjr1BwAvLy/Y29vjwoUL5T5uZmYGa2trjRtpyr1TcfipSj8iIiJDMmgAMjU1RYcOHZCYmKhuU6lUSExMRFBQULnbBAUFafQHgAMHDlTYHwCuXr2KmzdvwsWFi3SrytFKodd+REREhmTwn8FHRkZi3bp12LRpE86ePYvx48ejsLAQERERAIBRo0YhKipK3f/tt99GQkICli9fjnPnzmHevHn47bffMGHCBADA3bt3MW3aNBw9ehSXLl1CYmIiBg4cCB8fH4SEhBikxvqgo6cdXGwUkFXwuAyPfg3W0dOuNqdFRERUJQZfAxQWFobr169j7ty5yM7Ohp+fHxISEtQLna9cuQK5/H857bnnnsPWrVsxe/ZsvPvuu/D19cW3336LNm3aAABMTExw8uRJbNq0CXl5eXB1dUWfPn0wf/58mJmZGaTG+sBELkP0gFYYvyUNMkBjMXRpKIoe0Aom8ooiEhERUd1h8PMA1UU8D1DFeB4gIiKqq3T5/Db4ESAyLqFtXNC7lTNSMm8h9859OFo9+tqLR36IiMiYMACRzkzkMv7UnYiIjJrBF0ETERER1TYGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikpwGhp4AkaEoVQIpmbeQe+c+HK0U6OhpBxO5zNDT0ll9qYPqFr6v6ha+HvpXJwLQmjVrsHTpUmRnZ6N9+/b48MMP0bFjxwr779ixA3PmzMGlS5fg6+uLxYsXo1+/furHhRCIjo7GunXrkJeXh86dOyMuLg6+vr61UQ4ZgYRTWYjZfQZZ+ffVbS42CkQPaIXQNi4GnJlu6ksdVLfwfVW38PWoGQb/Ciw+Ph6RkZGIjo5GWloa2rdvj5CQEOTm5pbb/8iRIwgPD8fYsWNx4sQJDBo0CIMGDcKpU6fUfZYsWYJVq1bh448/xrFjx2BpaYmQkBDcv3+/3DFJWhJOZWH8ljSNPyYAkJ1/H+O3pCHhVJaBZqab+lIH1S18X9UtfD1qjkwIIQw5gcDAQDz77LNYvXo1AEClUsHNzQ0TJ07EzJkzy/QPCwtDYWEh9uzZo27r1KkT/Pz88PHHH0MIAVdXV0yZMgVTp04FAOTn58PJyQkbN27EiBEjnjingoIC2NjYID8/H9bW1nqqlOoCpUqgy+JDZf6YlJIBcLZR4JcZz9fpw8v1pQ6qW/i+qlv4euhOl89vgx4BKikpQWpqKoKDg9VtcrkcwcHBSE5OLneb5ORkjf4AEBISou6fmZmJ7OxsjT42NjYIDAyscMzi4mIUFBRo3Kh+Ssm8VeEfEwAQALLy7yMl81btTaoK6ksdVLfwfVW38PWoWQYNQDdu3IBSqYSTk5NGu5OTE7Kzs8vdJjs7u9L+pf+ry5ixsbGwsbFR39zc3KpUD9V9uXe0+xpU236GUl/qoLqF76u6ha9HzTL4GqC6ICoqCvn5+erb33//begpUQ1xtFLotZ+h1Jc6qG7h+6pu4etRswwagOzt7WFiYoKcnByN9pycHDg7O5e7jbOzc6X9S/9XlzHNzMxgbW2tcaP6qaOnHVxsFKjo23IZHv26oqOnXW1OS2f1pQ6qW/i+qlv4etQsgwYgU1NTdOjQAYmJieo2lUqFxMREBAUFlbtNUFCQRn8AOHDggLq/p6cnnJ2dNfoUFBTg2LFjFY5J0mEilyF6QCsAKPNHpfR+9IBWdX5BYX2pg+oWvq/qFr4eNcvgX4FFRkZi3bp12LRpE86ePYvx48ejsLAQERERAIBRo0YhKipK3f/tt99GQkICli9fjnPnzmHevHn47bffMGHCBACATCbD5MmTsWDBAuzatQt//PEHRo0aBVdXVwwaNMgQJVIdE9rGBXGv+sPZRvOwsbONAnGv+hvNeTXqSx1Ut/B9Vbfw9ag5Bv8ZPACsXr1afSJEPz8/rFq1CoGBgQCAHj16wMPDAxs3blT337FjB2bPnq0+EeKSJUvKPRHi2rVrkZeXhy5duuCjjz5C8+bNtZoPfwYvDfXlzKr1pQ6qW/i+qlv4emhHl8/vOhGA6hoGICIiIuNjNOcBIiIiIjIEBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikpwGhp5AXVR6cuyCggIDz4SIiIi0Vfq5rc1FLhiAynHnzh0AgJubm4FnQkRERLq6c+cObGxsKu3Da4GVQ6VS4dq1a7CysoJMpt+LzRUUFMDNzQ1///23UV9njHXULayjbmEddQvrqFtqsg4hBO7cuQNXV1fI5ZWv8uERoHLI5XI0a9asRvdhbW1t1G/gUqyjbmEddQvrqFtYR91SU3U86chPKS6CJiIiIslhACIiIiLJYQCqZWZmZoiOjoaZmZmhp1ItrKNuYR11C+uoW1hH3VJX6uAiaCIiIpIcHgEiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEA0tK8efMgk8k0bk8//bT68YsXL2Lw4MFwcHCAtbU1XnrpJeTk5GiM8eeff2LgwIGwt7eHtbU1unTpgsOHDz9x3ydPnkTXrl2hUCjg5uaGJUuWGF0d9+/fx5gxY9C2bVs0aNAAgwYNqnINhqwjKSkJAwcOhIuLCywtLeHn54cvvvjC6Oo4f/48evbsCScnJygUCnh5eWH27Nl48OCBUdXxbxcuXICVlRUaN25cpRoMWcelS5fK7Fcmk+Ho0aNGVQfw6Ey8y5YtQ/PmzWFmZoamTZvivffeM6o6ytuvTCaDpaWlUdUBAPv27UOnTp1gZWUFBwcHDB06FJcuXTK6OrZv3w4/Pz9YWFjA3d0dS5curVIN/8YApIPWrVsjKytLffvll18AAIWFhejTpw9kMhkOHTqEX3/9FSUlJRgwYABUKpV6+/79++Phw4c4dOgQUlNT0b59e/Tv3x/Z2dkV7rOgoAB9+vSBu7s7UlNTsXTpUsybNw9r1641qjqUSiXMzc0xadIkBAcHV3nuhq7jyJEjaNeuHb766iucPHkSERERGDVqFPbs2WNUdTRs2BCjRo3C/v37cf78eaxYsQLr1q1DdHS0UdVR6sGDBwgPD0fXrl2rPP+6UMfBgwc19t2hQwejq+Ptt9/Gp59+imXLluHcuXPYtWsXOnbsaFR1TJ06VWOfWVlZaNWqFYYPH25UdWRmZmLgwIF4/vnnkZ6ejn379uHGjRsYMmSIUdXxww8/4JVXXsG4ceNw6tQpfPTRR/jggw+wevXqKtcBABCklejoaNG+fftyH9u3b5+Qy+UiPz9f3ZaXlydkMpk4cOCAEEKI69evCwDip59+UvcpKCgQANR9yvPRRx8JW1tbUVxcrG6bMWOGaNGihVHV8W+jR48WAwcOrNL8S9WFOkr169dPRERE6F6EqFt1vPPOO6JLly66FyEMX8f06dPFq6++KjZs2CBsbGyqVIMh68jMzBQAxIkTJ6o897pQx5kzZ0SDBg3EuXPnjLqOx6Wnp5cZxxjq2LFjh2jQoIFQKpXqtl27dgmZTCZKSkqMpo7w8HAxbNgwjbZVq1aJZs2aCZVKpXMdpXgESAcZGRlwdXWFl5cXXnnlFVy5cgUAUFxcDJlMpnFSJ4VCAblcrk7HTZo0QYsWLfD555+jsLAQDx8+xCeffAJHR8dK/ysvOTkZ3bp1g6mpqbotJCQE58+fx+3bt42mjppQV+rIz8+HnZ2dUddx4cIFJCQkoHv37kZXx6FDh7Bjxw6sWbOmynOvC3UAwIsvvghHR0d06dIFu3btMro6du/eDS8vL+zZsweenp7w8PDAa6+9hlu3bhlVHY/79NNP0bx582odYTREHR06dIBcLseGDRugVCqRn5+PzZs3Izg4GA0bNjSaOoqLi6FQKDTazM3NcfXqVVy+fLlKdQDgESBt7d27V2zfvl38/vvvIiEhQQQFBYmnnnpKFBQUiNzcXGFtbS3efvttUVhYKO7evSsmTJggAIg33nhDPcbff/8tOnToIGQymTAxMREuLi4iLS2t0v327t1bYwwhhDh9+rQAIM6cOWM0dfybPo4A1YU6hBAiPj5emJqailOnThllHUFBQcLMzEw95r//S9EY6rhx44Zwc3MTP/74oxBCVPsIkKHquH79uli+fLk4evSoSElJETNmzBAymUx89913RlXHm2++KczMzERgYKD46aefxOHDh4Wfn5/o2bOnUdXxb/fu3RO2trZi8eLFVarB0HUkJSUJR0dHYWJiIgCIoKAgcfv2baOq45NPPhEWFhbi4MGDQqlUivPnz4unn35aABBHjhypUi1CCMEAVEW3b98W1tbW4tNPPxVCPDr85+XlpX5RX331VeHv7y/GjRsnhBBCpVKJF198UfTt21f88ssvIjU1VYwfP140bdpUXLt2TQghRKtWrYSlpaWwtLQUoaGhQgj9ByBD1fFv+ghAdaGOQ4cOCQsLC7Fp0yajrePKlSvi9OnTYuvWraJp06bV+iNviDoGDx4sZsyYod5vdQOQoeooz8iRI6v8laSh6nj99dcFAHH+/Hn1vlNTUwUAvXwtZojXY+vWraJBgwYiOzu72vOv7TqysrKEr6+vmDZtmkhLSxM//vij6N69u+jVq1e1vjqq7TpUKpWYPn26UCgUwsTERNja2op58+YJAOLo0aNVnj8DUDUEBASImTNnarRdv35dna6dnJzEkiVLhBBCHDx4sMz3o0II4ePjI2JjY4UQQly6dElkZGSIjIwMcfXqVSHEoz+Cj4eFQ4cOCQDi1q1bRlPHv9VEAKrtOpKSkoSlpaX45JNPjLqOf9u8ebMwNzcXDx8+NJo6bGxshImJifoml8sFAGFiYiI+++wzo6mjPKtXrxbOzs56qaG26pg7d65o0KCBxjZFRUUCgNi/f7/R1PFvzz//vBg0aJBe5l7bdcyePVsEBARobPP3338LACI5Odlo6ij18OFDcfXqVVFcXCz27t0rAIjc3Nwqz71B1b88k7a7d+/i4sWLGDlypEa7vb09gEfrEnJzc/Hiiy8CAIqKigAAcrnmsiu5XK5eIe/u7l5mP0FBQZg1axYePHig/s72wIEDaNGiBWxtbY2mjppWm3UkJSWhf//+WLx4Md544w2jreNxKpUKDx48gEqlgomJiVHUkZycDKVSqb7/3XffYfHixThy5AiaNm1arRpqs47ypKenw8XFpVrzL1VbdXTu3BkPHz7ExYsX4e3tDeDRz54r6l9X6yiVmZmJw4cPV3s91uNqq46ioqIy25T+f/vfv8yq63X8e+6l/7/+8ssvERQUBAcHh6oXUOXoJDFTpkwRSUlJIjMzU/z6668iODhY2Nvbq9Pn+vXrRXJysrhw4YLYvHmzsLOzE5GRkertr1+/Lpo0aSKGDBki0tPTxfnz58XUqVNFw4YNRXp6eoX7zcvLE05OTmLkyJHi1KlTYtu2bcLCwqLKRx4MVYcQj766O3HihBgwYIDo0aOHOHHiRJV/9WKoOkq/9oqKihJZWVnq282bN42qji1btoj4+Hhx5swZcfHiRREfHy9cXV3FK6+8YlR1PK66X4EZqo6NGzeKrVu3irNnz4qzZ8+K9957T8jlcrF+/XqjqkOpVAp/f3/RrVs3kZaWJn777TcRGBgoevfubVR1lJo9e7ZwdXWt9lFRQ9WRmJgoZDKZiImJEX/++adITU0VISEhwt3dXRQVFRlNHdevXxdxcXHi7Nmz4sSJE2LSpElCoVCIY8eO6VzDvzEAaSksLEy4uLgIU1NT0bRpUxEWFiYuXLigfnzGjBnCyclJNGzYUPj6+orly5eX+Y71+PHjok+fPsLOzk5YWVmJTp06ib179z5x37///rvo0qWLMDMzE02bNhWLFi0yyjrc3d0FgDI3Y6pj9OjR5dbQvXt3o6pj27Ztwt/fXzRq1EhYWlqKVq1aiYULF4p79+4ZVR2Pq24AMlQdGzduFC1bthQWFhbC2tpadOzYUezYscPo6hBCiH/++UcMGTJENGrUSDg5OYkxY8ZU+T8QDFmHUqkUzZo1E++++26V5l5X6vjyyy/FM888IywtLYWDg4N48cUXxdmzZ42qjuvXr4tOnToJS0tLYWFhIXr16lWttT+lZEIIUfXjR0RERETGh+cBIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiMpCkpCTIZDLk5eUZeip1xrx58+Dn51fh49o8Zxs3bkTjxo2fuK/PPvsMffr0Ud8fM2YMBg0apP1k6yht66/vbty4AUdHR1y9etXQU6E6igGIJE2pVOK5557DkCFDNNrz8/Ph5uaGWbNm1di+n3vuOWRlZcHGxqbG9jFv3jzIZDLIZDKYmJjAzc0Nb7zxBm7dulVj+6xJ+nrO7t+/jzlz5iA6OlpPMytLJpPh22+/fWI/Dw8P9WtUelu0aFGNzcvQtH1eqsve3h6jRo2q0deYjBsDEEmaiYkJNm7ciISEBHzxxRfq9okTJ8LOzq5G/3iamprC2dkZMpmsxvYBAK1bt0ZWVhauXLmCDRs2ICEhAePHj6/RfT7JgwcPqrSdvp6znTt3wtraGp07d67WOPry3//+F1lZWerbxIkTDT2lMqr6mtUUbeYTERGBL774wmgDP9UsBiCSvObNm2PRokWYOHEisrKy8N1332Hbtm34/PPPYWpqWuF2M2bMQPPmzWFhYQEvLy/MmTNH/UdZCIHg4GCEhISg9HJ7t27dQrNmzTB37lwAZb/OuXz5MgYMGABbW1tYWlqidevW2Lt3b7Xra9CgAZydndG0aVMEBwdj+PDhOHDggEafTz/9FC1btoRCocDTTz+Njz76SOPxq1evIjw8HHZ2drC0tERAQACOHTumfjwuLg7e3t4wNTVFixYtsHnzZo3tZTIZ4uLi8OKLL8LS0hLvvfceAGDRokVwcnKClZUVxo4di/v371daS3lfgW3cuBFPPfUULCwsMHjwYNy8efOJz8m2bdswYMCASvskJCSgS5cuaNy4MZo0aYL+/fvj4sWL6sdLSkowYcIEuLi4QKFQwN3dHbGxsQAeHdUBgMGDB0Mmk6nvV8TKygrOzs7qm6WlZaX98/Ly8Oabb8LJyQkKhQJt2rTBnj17NPrs27cPLVu2RKNGjRAaGoqsrCz1Y8ePH0fv3r1hb28PGxsbdO/eHWlpaRrbl/eaKZVKjB07Fp6enjA3N0eLFi2wcuXKMvNbv349WrduDTMzM7i4uGDChAlPfF6+++47+Pv7Q6FQwMvLCzExMXj48GGl87l9+zZeeeUVODg4wNzcHL6+vtiwYYN6m9atW8PV1RXffPNNpc8nSVS1L6dKVA+oVCrRo0cP0atXL+Ho6Cjmz5//xG3mz58vfv31V5GZmSl27dolnJycxOLFi9WPX716Vdja2ooVK1YIIYQYPny46Nixo3jw4IEQQojDhw8LAOL27dtCCCFeeOEF0bt3b3Hy5Elx8eJFsXv3bvHjjz9Wq67o6GjRvn179f3MzEzRunVr4eTkpG7bsmWLcHFxEV999ZX466+/xFdffSXs7OzExo0bhRBC3LlzR3h5eYmuXbuKn3/+WWRkZIj4+Hhx5MgRIYQQX3/9tWjYsKFYs2aNOH/+vFi+fLkwMTERhw4dUu8DgHB0dBTr168XFy9eFJcvXxbx8fHCzMxMfPrpp+LcuXNi1qxZwsrKSmO+j3v8OTt69KiQy+Vi8eLF4vz582LlypWicePGT7wivI2Njdi2bZtG2+jRo8XAgQPV93fu3Cm++uorkZGRIU6cOCEGDBgg2rZtK5RKpRBCiKVLlwo3Nzfx008/iUuXLomff/5ZbN26VQghRG5urgAgNmzYILKyskRubm6Fc3F3dxdOTk7Czs5O+Pn5iSVLlqjfI+VRKpWiU6dOonXr1mL//v3q90rpFbU3bNggGjZsKIKDg8Xx48dFamqqaNmypXj55ZfVYyQmJorNmzeLs2fPijNnzoixY8cKJycnUVBQoO5T3mtWUlIi5s6dK44fPy7++usvsWXLFmFhYSHi4+PV23300UdCoVCIFStWiPPnz4uUlBTxwQcfVPq8/PTTT8La2lps3LhRXLx4Uezfv194eHiIefPmVTqf//u//xN+fn7i+PHjIjMzUxw4cEDs2rVL4/kKCwsTo0ePrvD5JOliACL6/86ePSsAiLZt21b6AVSRpUuXig4dOmi0bd++XSgUCjFz5kxhaWkp/vzzT/Vjj3+Yt23bVuMPvj5ER0cLuVwuLC0thUKhEAAEAPH++++r+3h7e6s/uEvNnz9fBAUFCSGE+OSTT4SVlZW4efNmuft47rnnxOuvv67RNnz4cNGvXz/1fQBi8uTJGn2CgoLEW2+9pdEWGBioUwAKDw/X2I8Qjz7wKgtAt2/fFgDETz/9pNH+eAB63PXr1wUA8ccffwghhJg4caJ4/vnnhUqlKrc/APHNN99UOF6p5cuXi8OHD4vff/9dxMXFicaNG4t33nmnwv779u0TcrlcnD9/vtzHN2zYIACICxcuqNvWrFmjEXofp1QqhZWVldi9e7fG/B9/zcrzf//3f2Lo0KHq+66urmLWrFkV9i/veenVq5dYuHChRtvmzZuFi4tLpfMZMGCAiIiIqHR+77zzjujRo8eTyiAJ4ldgRP/f+vXrYWFhgczMTI1fjowbNw6NGjVS30rFx8ejc+fOcHZ2RqNGjTB79mxcuXJFY8zhw4dj8ODBWLRoEZYtWwZfX98K9z9p0iQsWLAAnTt3RnR0NE6ePFlh34ULF2rM6fH9/luLFi2Qnp6O48ePY8aMGQgJCVGvMSksLMTFixcxduxYjfEWLFig/ronPT0dzzzzDOzs7Mod/+zZs2XW0nTu3Blnz57VaAsICCizXWBgoEZbUFBQhXVUtG9dx7h37x4AQKFQVNovIyMD4eHh8PLygrW1tfrrmtLnesyYMUhPT0eLFi0wadIk7N+/X6e5l4qMjESPHj3Qrl07jBs3DsuXL8eHH36I4uLicvunp6ejWbNmaN68eYVjWlhYwNvbW33fxcUFubm56vs5OTl4/fXX4evrCxsbG1hbW+Pu3btl3kePv2YAsGbNGnTo0AEODg5o1KgR1q5dq94uNzcX165dQ69evXR6Dn7//Xf897//1XgPvv7668jKykJRUVGF8xk/fjy2bdsGPz8/TJ8+HUeOHCkztrm5ucYYRKUYgIgAHDlyBB988AH27NmDjh07YuzYseq1O//973+Rnp6uvgFAcnIyXnnlFfTr1w979uzBiRMnMGvWLJSUlGiMW1RUhNTUVJiYmCAjI6PSObz22mv466+/MHLkSPzxxx8ICAjAhx9+WG7fcePGaczJ1dW1wnFNTU3h4+ODNm3aYNGiRTAxMUFMTAwA4O7duwCAdevWaYx36tQpHD16FMCjDxB9eNK6ltrSpEkTyGQy3L59u9J+AwYMwK1bt7Bu3TocO3ZMveap9DX29/dHZmYm5s+fj3v37uGll17CsGHDqj2/wMBAPHz4EJcuXSr3cW1ej4YNG2rcl8lk6vczAIwePRrp6elYuXIljhw5gvT0dDRp0qTM+/fx12zbtm2YOnUqxo4di/379yM9PR0RERHq7ar6Xrl79y5iYmI03oN//PEHMjIyNILq4/Pp27cvLl++jHfeeUcdvKZOnarR59atW3BwcKjSvKh+YwAiySsqKsKYMWMwfvx49OzZE5999hlSUlLw8ccfAwAcHR3h4+OjvgGPApO7uztmzZqFgIAA+Pr64vLly2XGnjJlCuRyOX744QesWrUKhw4dqnQubm5uGDduHL7++mtMmTIF69atK7efnZ2dxpwaNGigdb2zZ8/GsmXLcO3aNTg5OcHV1RV//fWXxng+Pj7w9PQEALRr1w7p6ekV/pKmZcuW+PXXXzXafv31V7Rq1arSebRs2VJjITUAdejSVlXGMDU1RatWrXDmzJkK+9y8eRPnz5/H7Nmz0atXL7Rs2bLcwGRtbY2wsDCsW7cO8fHx+Oqrr9TPU8OGDaFUKnWqB3h0hEcul8PR0bHcx9u1a4erV6/izz//1HnsUr/++ismTZqEfv36qRcr37hxQ6vtnnvuObz11lt45pln4OPjo7Ew3MrKCh4eHkhMTKxwjPKeF39/f5w/f77Me9DHxwdyeeUfUw4ODhg9ejS2bNmCFStWYO3atRqPnzp1Cs8888wTayPp0f6vJlE9FRUVBSGE+twrHh4eWLZsGaZOnYq+ffuW+wseX19fXLlyBdu2bcOzzz6L77//vswvTb7//nusX78eycnJ8Pf3x7Rp0zB69GicPHkStra2ZcacPHky+vbti+bNm+P27ds4fPgwWrZsqfd6g4KC0K5dOyxcuBCrV69GTEwMJk2aBBsbG4SGhqK4uBi//fYbbt++jcjISISHh2PhwoUYNGgQYmNj4eLighMnTsDV1RVBQUGYNm0aXnrpJTzzzDMIDg7G7t278fXXX+PgwYOVzuPtt9/GmDFjEBAQgM6dO+OLL77A6dOn4eXlpXUtkyZNQufOnbFs2TIMHDgQ+/btQ0JCwhO3CwkJwS+//ILJkyeX+7itrS2aNGmCtWvXwsXFBVeuXMHMmTM1+rz//vtwcXHBM888A7lcjh07dsDZ2Vl9EsLSINC5c2eYmZmV+5onJyfj2LFj6NmzJ6ysrJCcnIx33nkHr776arn9AaB79+7o1q0bhg4divfffx8+Pj44d+4cZDIZQkNDn1g78Oj9u3nzZgQEBKCgoADTpk3T6uiNr68vPv/8c+zbtw+enp7YvHkzjh8/rg7LwKNzT40bNw6Ojo7o27cv7ty5g19//VX9tWt5z8vcuXPRv39/PPXUUxg2bBjkcjl+//13nDp1CgsWLKhwPnPnzkWHDh3QunVrFBcXY8+ePRr/nyk9Artw4UKtnheSGAOvQSIyqKSkJGFiYiJ+/vnnMo/16dOn0kWu06ZNE02aNBGNGjUSYWFh4oMPPlAvvs3NzRVOTk4aCztLSkpEhw4dxEsvvSSEKLugd8KECcLb21uYmZkJBwcHMXLkSHHjxo1q1ff4r8BKffnll8LMzExcuXJFCCHEF198Ifz8/ISpqamwtbUV3bp1E19//bW6/6VLl8TQoUOFtbW1sLCwEAEBAeLYsWPqxz/66CPh5eUlGjZsKJo3by4+//xzjf2hggXB7733nrC3txeNGjUSo0ePFtOnT9dpEbQQQnz22WeiWbNmwtzcXAwYMEAsW7bsib8CO336tDA3Nxd5eXnqtscXQR84cEC0bNlSmJmZiXbt2omkpCSNOtauXSv8/PyEpaWlsLa2Fr169RJpaWnq7Xft2iV8fHxEgwYNhLu7e7nzSE1NFYGBgcLGxkYoFArRsmVLsXDhQnH//v1K53/z5k0REREhmjRpIhQKhWjTpo3Ys2ePEOLRIujH6//mm2/Ev//cp6WliYCAAKFQKISvr6/YsWOHcHd3V/9aS4jyX7P79++LMWPGCBsbG9G4cWMxfvx4MXPmzDKv2ccffyxatGghGjZsKFxcXMTEiROf+LwkJCSI5557Tpibmwtra2vRsWNHsXbt2krnM3/+fNGyZUthbm4u7OzsxMCBA8Vff/2lfnzr1q2iRYsWlT6XJF0yIf71xTARkUQMHz4c/v7+iIqKMvRUqIZ06tQJkyZNwssvv2zoqVAdxDVARCRJS5cu1fhVH9UvN27cwJAhQxAeHm7oqVAdxSNAREREJDk8AkRERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLz/wCHsdGel9TVRQAAAABJRU5ErkJggg=="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 37
   },
   {
    "cell_type": "markdown",
@@ -985,9 +1673,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:17.340328Z",
+     "start_time": "2024-09-18T11:06:17.261861Z"
+    }
+   },
    "source": [
     "import matplotlib.pyplot as plt\n",
     "plt.scatter(x, y_rougelsum, marker='o')\n",
@@ -999,7 +1690,20 @@
     "\n",
     "# Display the graph\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAHHCAYAAABXx+fLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABWWklEQVR4nO3deViUVf8G8HsGhGEdQHYlQERySUkRJHFJUdA0lzSkzOVVS3vTDDUlUyRN1KzM3BJzSTOx1TTDBSUrUUwkxYXUcEsWN8AlQWfO7w9/zOvI4gwODONzf65rrtc5z5nzfM/MvMzds8qEEAJEREREEiI3dgFEREREtY0BiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiKptxowZkMlkxi6DDKxz587o3LnzQ/v5+Phg2LBhD+23evVqyGQynDlz5pFrIzIUBiAiIiKSHHNjF0BERKYpOzsbcjn/O5pME7+5RHXMzZs3jV0CGVhd+0wNVY+lpSXq1atnkLGIahsDEJERlR1Dc+zYMbz00ktwdHREWFgYAODu3buYOXMm/Pz8YGlpCR8fH7zzzjsoKSnRGkMmk2HGjBnlxq7o+IzDhw+jU6dOsLKyQsOGDTFr1iysWrWqwuMzfv75Z3To0AE2Njaws7PDc889h6NHjz50Tjt27EBYWBgcHBxga2uLgIAAvPPOO5rllR0PkpqaCplMhtTUVE1b586d0aJFC03d1tbWaNy4Mb755hsAwC+//IKQkBBYWVkhICAAO3furLK2/Px8mJubIz4+vtyy7OxsyGQyLFq0CABw584dxMfHw9/fHwqFAvXr10dYWBh27NhR5TrK5vfLL7/g9ddfh6urKxo2bKhZruv7euLECbz44otwcXHRzG/q1KlafQ4dOoQePXrA3t4etra26Nq1K/bt26dXPcuXL4efnx+srKwQHByMX3/9tcr53a+i79jRo0fRpUsXre+YWq3WeUyi2sJdYER1wMCBA+Hv74/Zs2dDCAEAGDlyJNasWYMBAwZgwoQJ2L9/PxISEnD8+HF8//33eq/jn3/+wbPPPguZTIbY2FjY2NhgxYoVsLS0LNd37dq1GDp0KCIiIjB37lzcunULS5cuRVhYGA4dOgQfH58K13H06FH06tULLVu2xHvvvQdLS0ucOnUKv//+u971lrl27Rp69eqFQYMGYeDAgVi6dCkGDRqEL7/8EuPHj8fo0aPx0ksv4YMPPsCAAQNw/vx52NnZVTiWm5sbOnXqhI0bNyIuLk5rWVJSEszMzDBw4EAA98JpQkICRo4cieDgYBQXF+OPP/5ARkYGunXr9tC6X3/9dbi4uGD69OmaLS66vq+HDx9Ghw4dUK9ePbz66qvw8fHB6dOnsXnzZrz//vsA7r3XHTp0gL29Pd5++23Uq1cPn332GTp37qwJhg+r5/PPP8drr72GZ555BuPHj8fff/+N559/Hk5OTvDy8tL9Q/p/eXl5ePbZZ3H37l1MmTIFNjY2WL58OaysrPQei6jGCSIymri4OAFAREdHa7VnZmYKAGLkyJFa7RMnThQAxK5duzRtAERcXFy5sb29vcXQoUM1z8eOHStkMpk4dOiQpu3KlSvCyclJABA5OTlCCCGuX78uHBwcxKhRo7TGy8vLE0qlUqu9rP4yH3/8sQAgLl26VOmcV61apbW+Mrt37xYAxO7duzVtnTp1EgDE+vXrNW0nTpwQAIRcLhf79u3TtG/btk0AEKtWrap03UII8dlnnwkA4siRI1rtzZo1E126dNE8b9WqlXjuueeqHKuq+YWFhYm7d+9q2vV5Xzt27Cjs7OzE2bNntfqq1WrNv/v27SssLCzE6dOnNW0XL14UdnZ2omPHjg+tp7S0VLi6uorAwEBRUlKiaV++fLkAIDp16vTQuT74HRs/frwAIPbv369pKygoEEqlssLPnMiYuAuMqA4YPXq01vOtW7cCAGJiYrTaJ0yYAAD46aef9F5HcnIyQkNDERgYqGlzcnLCyy+/rNVvx44dKCwsRHR0NC5fvqx5mJmZISQkBLt37650HQ4ODgCATZs2GWy3h62tLQYNGqR5HhAQAAcHBzRt2lRrK0fZv//+++8qx+vfvz/Mzc2RlJSkacvKysKxY8cQFRWlaXNwcMDRo0dx8uTJatU9atQomJmZaZ7r+r5eunQJe/bswX/+8x888cQTWmOWXXJApVJh+/bt6Nu3Lxo1aqRZ7uHhgZdeegm//fYbiouLq6znjz/+QEFBAUaPHg0LCwtN+7Bhw6BUKqs1561bt6Jdu3YIDg7WtLm4uJT7jhHVBQxARHWAr6+v1vOzZ89CLpejcePGWu3u7u5wcHDA2bNn9V7H2bNny40HoFxb2Q9+ly5d4OLiovXYvn07CgoKKl1HVFQU2rdvj5EjR8LNzQ2DBg3Cxo0bHykMNWzYsNy1hpRKZbldNGU/2teuXatyPGdnZ3Tt2hUbN27UtCUlJcHc3Bz9+/fXtL333nsoLCxEkyZN8NRTT2HSpEk4fPiwznU/+Jnq+r6WBbgWLVpUOvalS5dw69YtBAQElFvWtGlTqNVqnD9/vsp6yr5D/v7+Wu316tXTClX6OHv2bLnxAFRYJ5Gx8RggojqgsmMkHuUigyqVqlqvKwsra9euhbu7e7nl5uaV/9mwsrLCnj17sHv3bvz0009ITk5GUlISunTpgu3bt8PMzKzSOVVW7/1bLXRpF/9/DFVVBg0ahOHDhyMzMxOBgYHYuHEjunbtCmdnZ02fjh074vTp09i0aRO2b9+OFStW4OOPP8ayZcswcuTIh67jwc/0Ud5XQ+BxOETaGICI6iBvb2+o1WqcPHkSTZs21bTn5+ejsLAQ3t7emjZHR0cUFhZqvb60tBS5ubnlxjx16lS5dT3Y5ufnBwBwdXVFeHi43rXL5XJ07doVXbt2xUcffYTZs2dj6tSp2L17N8LDw+Ho6AgA5Wquzlat6urbty9ee+01zW6wv/76C7GxseX6OTk5Yfjw4Rg+fDhu3LiBjh07YsaMGToFoAfp+r6WbX3JysqqtI+Liwusra2RnZ1dbtmJEycgl8sfehBz2Xfo5MmT6NKli6b9zp07yMnJQatWrap8fWVjVrTLsKI6iYyNu8CI6qCePXsCABYsWKDV/tFHHwEAnnvuOU2bn58f9uzZo9Vv+fLl5baoREREIC0tDZmZmZq2q1ev4ssvvyzXz97eHrNnz8adO3fK1Xbp0qVK67569Wq5trJjjspO3y8LAvfXrFKpsHz58krHNTQHBwdERERg48aN2LBhAywsLNC3b1+tPleuXNF6bmtri8aNG5e7DIGudH1fXVxc0LFjR6xcuRLnzp3T6lO2dcvMzAzdu3fHpk2btC4nkJ+fj/Xr1yMsLAz29vZV1hMUFAQXFxcsW7YMpaWlmvbVq1eXC6e66tmzJ/bt24f09HSteT34HSOqC7gFiKgOatWqFYYOHYrly5ejsLAQnTp1Qnp6OtasWYO+ffvi2Wef1fQdOXIkRo8ejRdeeAHdunXDn3/+iW3btmntzgGAt99+G+vWrUO3bt0wduxYzWnwTzzxBK5evarZNWVvb4+lS5filVdeQevWrTFo0CC4uLjg3Llz+Omnn9C+fXvNtXIe9N5772HPnj147rnn4O3tjYKCAixZsgQNGzbUXN+oefPmaNeuHWJjY3H16lU4OTlhw4YNuHv3bg29mxWLiorC4MGDsWTJEkRERGgO4C7TrFkzdO7cGW3atIGTkxP++OMPfPPNN3jjjTeqtT593teFCxciLCwMrVu3xquvvgpfX1+cOXMGP/30kybAzpo1S3PNpddffx3m5ub47LPPUFJSgnnz5j20nnr16mHWrFl47bXX0KVLF0RFRSEnJwerVq2q9jFAb7/9NtauXYvIyEi8+eabmtPgvb299Tp+iqhWGPs0NCIpKzuNvKLTxu/cuSPi4+OFr6+vqFevnvDy8hKxsbHi9u3bWv1UKpWYPHmycHZ2FtbW1iIiIkKcOnWq3CnKQghx6NAh0aFDB2FpaSkaNmwoEhISxMKFCwUAkZeXp9V39+7dIiIiQiiVSqFQKISfn58YNmyY+OOPP8rVXyYlJUX06dNHeHp6CgsLC+Hp6Smio6PFX3/9pTX26dOnRXh4uLC0tBRubm7inXfeETt27KjwNPjmzZuXe2+8vb0rPEUdgPjvf/9b/o2uQHFxsbCyshIAxLp168otnzVrlggODhYODg7CyspKPPnkk+L9998XpaWlVY5bdtr5gQMHKlyuy/sqhBBZWVmiX79+wsHBQSgUChEQECCmTZum1ScjI0NEREQIW1tbYW1tLZ599lmxd+9evepZsmSJ8PX1FZaWliIoKEjs2bNHdOrUqVqnwQshxOHDh0WnTp2EQqEQDRo0EDNnzhSff/45T4OnOkcmhA5HDBLRY2v8+PH47LPPcOPGjUoPLCYietzwGCAiCfn333+1nl+5cgVr165FWFgYww8RSQqPASKSkNDQUHTu3BlNmzZFfn4+Pv/8cxQXF2PatGnGLo2IqFYxABFJSM+ePfHNN99g+fLlkMlkaN26NT7//HN07NjR2KUREdUqHgNEREREksNjgIiIiEhyGICIiIhIcngMUAXUajUuXrwIOzu7R7oXExEREdUeIQSuX78OT09PyOVVb+NhAKrAxYsXH3ofHSIiIqqbzp8/j4YNG1bZhwGoAnZ2dgDuvYEPu58OERER1Q3FxcXw8vLS/I5XhQGoAvffE4kBiIiIyLTocvgKD4ImIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIsmpEwFo8eLF8PHxgUKhQEhICNLT0yvt+9133yEoKAgODg6wsbFBYGAg1q5dq9VHCIHp06fDw8MDVlZWCA8Px8mTJ2t6GkRERGQijB6AkpKSEBMTg7i4OGRkZKBVq1aIiIhAQUFBhf2dnJwwdepUpKWl4fDhwxg+fDiGDx+Obdu2afrMmzcPCxcuxLJly7B//37Y2NggIiICt2/frq1pERERUR1m9LvBh4SEoG3btli0aBGAe7eh8PLywtixYzFlyhSdxmjdujWee+45zJw5E0IIeHp6YsKECZg4cSIAoKioCG5ubli9ejUGDRr00PGKi4uhVCpRVFTE6wARERGZCH1+v426Bai0tBQHDx5EeHi4pk0ulyM8PBxpaWkPfb0QAikpKcjOzkbHjh0BADk5OcjLy9MaU6lUIiQkRKcxiYiI6PFn1CtBX758GSqVCm5ublrtbm5uOHHiRKWvKyoqQoMGDVBSUgIzMzMsWbIE3bp1AwDk5eVpxnhwzLJlDyopKUFJSYnmeXFxcbXm8zAqtUB6zlUUXL8NVzsFgn2dYCbnzVaJiIhqm0neCsPOzg6ZmZm4ceMGUlJSEBMTg0aNGqFz587VGi8hIQHx8fGGLfIByVm5iN98DLlF/zsOyUOpQFzvZohs4VGj6yYiIiJtRt0F5uzsDDMzM+Tn52u15+fnw93dvdLXyeVyNG7cGIGBgZgwYQIGDBiAhIQEANC8Tp8xY2NjUVRUpHmcP3/+UaZVTnJWLsasy9AKPwCQV3QbY9ZlIDkr16DrIyIioqoZNQBZWFigTZs2SElJ0bSp1WqkpKQgNDRU53HUarVmF5avry/c3d21xiwuLsb+/fsrHdPS0lJz41ND3wBVpRaI33wMFR1pXtYWv/kYVGqjHotOREQkKUbfBRYTE4OhQ4ciKCgIwcHBWLBgAW7evInhw4cDAIYMGYIGDRpotvAkJCQgKCgIfn5+KCkpwdatW7F27VosXboUwL07wI4fPx6zZs2Cv78/fH19MW3aNHh6eqJv3761Pr/0nKvltvzcTwDILbqN9JyrCPWrX3uFERERSZjRA1BUVBQuXbqE6dOnIy8vD4GBgUhOTtYcxHzu3DnI5f/bUHXz5k28/vrruHDhAqysrPDkk09i3bp1iIqK0vR5++23cfPmTbz66qsoLCxEWFgYkpOToVAoan1+Bdd1u/aQrv2IiIjo0Rn9OkB1kSGvA5R2+gqiE/c9tN9Xo9pxCxAREdEjMJnrAElBsK8TPJQKVHayuwz3zgYL9nWqzbKIiIgkjQGohpnJZYjr3QwAyoWgsudxvZvxekBERES1iAGoFkS28MDSwa3hrtQ+BsldqcDSwa15HSAiIqJaZvSDoKUisoUHujVz55WgiYiI6gAGoFpkJpfxQGciIqI6gLvAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhy6kQAWrx4MXx8fKBQKBASEoL09PRK+yYmJqJDhw5wdHSEo6MjwsPDy/UfNmwYZDKZ1iMyMrKmp0FEREQmwugBKCkpCTExMYiLi0NGRgZatWqFiIgIFBQUVNg/NTUV0dHR2L17N9LS0uDl5YXu3bvjn3/+0eoXGRmJ3NxczeOrr76qjekQERGRCZAJIYQxCwgJCUHbtm2xaNEiAIBarYaXlxfGjh2LKVOmPPT1KpUKjo6OWLRoEYYMGQLg3hagwsJC/PDDD9Wqqbi4GEqlEkVFRbC3t6/WGERERFS79Pn9NuoWoNLSUhw8eBDh4eGaNrlcjvDwcKSlpek0xq1bt3Dnzh04OTlptaempsLV1RUBAQEYM2YMrly5UukYJSUlKC4u1noQERHR48uoAejy5ctQqVRwc3PTandzc0NeXp5OY0yePBmenp5aISoyMhJffPEFUlJSMHfuXPzyyy/o0aMHVCpVhWMkJCRAqVRqHl5eXtWfFBEREdV55sYu4FHMmTMHGzZsQGpqKhQKhaZ90KBBmn8/9dRTaNmyJfz8/JCamoquXbuWGyc2NhYxMTGa58XFxQxBREREjzGjbgFydnaGmZkZ8vPztdrz8/Ph7u5e5Wvnz5+POXPmYPv27WjZsmWVfRs1agRnZ2ecOnWqwuWWlpawt7fXehAREdHjy6gByMLCAm3atEFKSoqmTa1WIyUlBaGhoZW+bt68eZg5cyaSk5MRFBT00PVcuHABV65cgYeHh0HqJiIiItNm9NPgY2JikJiYiDVr1uD48eMYM2YMbt68ieHDhwMAhgwZgtjYWE3/uXPnYtq0aVi5ciV8fHyQl5eHvLw83LhxAwBw48YNTJo0Cfv27cOZM2eQkpKCPn36oHHjxoiIiDDKHImIiKhuMfoxQFFRUbh06RKmT5+OvLw8BAYGIjk5WXNg9Llz5yCX/y+nLV26FKWlpRgwYIDWOHFxcZgxYwbMzMxw+PBhrFmzBoWFhfD09ET37t0xc+ZMWFpa1urciIiIqG4y+nWA6iJeB4iIiMj0mMx1gIiIiIiMgQGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkx1zXju+9955O/aZPn17tYoiIiIhqg0wIIXTpKJfL4enpCVdXV1T2EplMhoyMDIMWaAzFxcVQKpUoKiqCvb29scshIiIiHejz+63zFqAePXpg165dCAoKwn/+8x/06tULcjn3oBEREZHp0TnB/PTTTzh9+jRCQkIwadIkNGjQAJMnT0Z2dnZN1kdERERkcHptwvH09ERsbCyys7ORlJSEgoICtG3bFu3bt8e///5bUzUSERERGZTOu8Ae1LZtW5w5cwbHjh3DoUOHcOfOHVhZWRmyNiIiIqIaofdBPGlpaRg1ahTc3d3x6aefYujQobh48eIjHSy8ePFi+Pj4QKFQICQkBOnp6ZX2TUxMRIcOHeDo6AhHR0eEh4eX6y+EwPTp0+Hh4QErKyuEh4fj5MmT1a6PiIiIHi86B6B58+ahWbNm6NOnD2xtbfHrr7/iwIEDeP311+Hg4FDtApKSkhATE4O4uDhkZGSgVatWiIiIQEFBQYX9U1NTER0djd27dyMtLQ1eXl7o3r07/vnnH61aFy5ciGXLlmH//v2wsbFBREQEbt++Xe06iYiI6PGh12nwTzzxBHr16gULC4tK+3300Ud6FRASEoK2bdti0aJFAAC1Wg0vLy+MHTsWU6ZMeejrVSoVHB0dsWjRIgwZMgRCCHh6emLChAmYOHEiAKCoqAhubm5YvXo1Bg0a9NAxeRo8ERGR6amR0+A7duwImUyGo0ePVtpHJpPpXiWA0tJSHDx4ELGxsZo2uVyO8PBwpKWl6TTGrVu3cOfOHTg5OQEAcnJykJeXh/DwcE0fpVKJkJAQpKWlVRiASkpKUFJSonleXFys1zyIiIjItOgcgFJTUw2+8suXL0OlUsHNzU2r3c3NDSdOnNBpjMmTJ8PT01MTePLy8jRjPDhm2bIHJSQkID4+Xt/yiYiIyESZ9JUM58yZgw0bNuD777+HQqGo9jixsbEoKirSPM6fP2/AKomIiKiu0XkLUP/+/StsVyqVaNKkCUaOHAkXFxe9Vu7s7AwzMzPk5+drtefn58Pd3b3K186fPx9z5szBzp070bJlS0172evy8/Ph4eGhNWZgYGCFY1laWsLS0lKv2omIiMh06bwFSKlUVvgoLCxEYmIiAgICkJWVpdfKLSws0KZNG6SkpGja1Go1UlJSEBoaWunr5s2bh5kzZyI5ORlBQUFay3x9feHu7q41ZnFxMfbv31/lmERERCQdOm8BWrVqVaXL1Go1Ro0ahdjYWGzevFmvAmJiYjB06FAEBQUhODgYCxYswM2bNzF8+HAAwJAhQ9CgQQMkJCQAAObOnYvp06dj/fr18PHx0RzXY2trC1tbW8hkMowfPx6zZs2Cv78/fH19MW3aNHh6eqJv37561UZERESPp2pfCfp+crkc48aNQ48ePfR+bVRUFC5duoTp06cjLy8PgYGBSE5O1hzEfO7cOa2bri5duhSlpaUYMGCA1jhxcXGYMWMGAODtt9/GzZs38eqrr6KwsBBhYWFITk5+pOOEiIiI6PGh83WAHubUqVMICgpCYWGhIYYzKl4HiIiIyPTo8/ttsLPAduzYgSZNmhhqOCIiIqIao/MusB9//LHC9qKiIhw8eBArVqzAihUrDFYYERERUU3ROQBVdgCxnZ0dAgICsGLFCp1uM0FERERkbDoHILVaXZN1EBEREdUak74SNBEREVF16ByA0tLSsGXLFq22L774Ar6+vnB1dcWrr76qdUNRIiIiorpK5wD03nvvad0J/siRIxgxYgTCw8MxZcoUbN68WXOxQiIiIqK6TOcAlJmZia5du2qeb9iwASEhIUhMTERMTAwWLlyIjRs31kiRRERERIakcwC6du2a5urMAPDLL79oXfm5bdu2vIs6ERERmQSdA5CbmxtycnIAAKWlpcjIyEC7du00y69fv4569eoZvkIiIiIiA9M5APXs2RNTpkzBr7/+itjYWFhbW6NDhw6a5YcPH4afn1+NFElERERkSDpfB2jmzJno378/OnXqBFtbW6xZswYWFhaa5StXrkT37t1rpEgiIiIiQ9L7ZqhFRUWwtbWFmZmZVvvVq1dhZ2f3WOwG481QiYiITE+N3gxVqVSWCz8AUFBQgObNm+s7HBEREVGtM9iVoEtKSnD69GlDDUdERERUY3grDCIiIpIcBiAiIiKSHAYgIiIikhydT4N3dHSETCardPndu3cNUhARERFRTdM5AH388cdVBiAiIiIiU6FzABo2bFgNlkFERERUe3Q+Big9PR0qlarS5SUlJbwbPBEREZkEnQNQaGgorly5onlub2+Pv//+W/O8sLAQ0dHRhq2OiIiIqAboHIAevGNGRXfQ0POuGkRERERGYdDT4HmQNBEREZkCXgeIiIiIJEfns8AA4NixY8jLywNwb3fXiRMncOPGDQDA5cuXDV8dERERUQ2QCR0P3JHL5ZDJZBUe51PWLpPJqjxTzFQUFxdDqVSiqKgI9vb2xi6HiIiIdKDP77fOW4BycnIeuTAiIiKiukDnAOTt7V2TdRARERHVGr2OASouLtZsUtq6davW/b/MzMzw3HPPGbY6IiIiohqgcwDasmULpk2bhkOHDgEAoqKicPPmTc1ymUyGpKQkDBgwwPBVEhERERmQzqfBL1++HGPHjtVqO3XqFNRqNdRqNRISErBy5UqDF0hERERkaDoHoCNHjqB9+/aVLu/Rowf++OMPgxRFREREVJN0DkC5ubmwtLTUPN+9eze8vLw0z21tbVFUVGTY6oiIiIhqgM4ByMnJCadOndI8DwoKQr169TTPT548CScnJ8NWR0RERFQDdA5AHTt2xMKFCytdvnDhQnTs2NEgRRERERHVJJ0D0OTJk7F9+3YMHDgQBw4cQFFREYqKipCeno4XXngBO3fuxOTJk2uyViIiIiKD0Pk0+KeffhpJSUkYOXIkvvvuO61ljo6O2LBhA1q3bm3wAomIiIgMTed7gZW5desWtm3bhpMnTwIA/P390b17d9jY2NRIgcbAe4ERERGZnhq5F1gZa2tr9OvXr9rFERERERmbzgEoJiamwnalUokmTZqgf//+WqfJExEREdVVOgegsltgPKiwsBCnTp3CtGnTsGvXLjzxxBMGK46IiIioJuh9DFBFiouL8fLLL8POzg7r1683RF1GxWOAiIiITI8+v986nwZfFXt7e0ybNg2///67IYYjIiIiqlEGCUAA4OzsjKtXrxpqOCIiIqIaY7AAtG/fPvj5+en9usWLF8PHxwcKhQIhISFIT0+vtO/Ro0fxwgsvwMfHBzKZDAsWLCjXZ8aMGZDJZFqPJ598Uu+6iIiI6PGl80HQhw8frrC9qKgIBw8exOzZsxEXF6fXypOSkhATE4Nly5YhJCQECxYsQEREBLKzs+Hq6lqu/61bt9CoUSMMHDgQb731VqXjNm/eHDt37tQ8NzfX+2x/IiIieozpnAwCAwMhk8lQ0THTzs7OiImJweuvv67Xyj/66COMGjUKw4cPBwAsW7YMP/30E1auXIkpU6aU69+2bVu0bdsWACpcXsbc3Bzu7u561UJERETSoXMAysnJqbDd3t4ejo6Oeq+4tLQUBw8eRGxsrKZNLpcjPDwcaWlpeo93v5MnT8LT0xMKhQKhoaFISEio8vT8kpISlJSUaJ4XFxc/0vqJiIiobtM5AHl7ext0xZcvX4ZKpYKbm5tWu5ubG06cOFHtcUNCQrB69WoEBAQgNzcX8fHx6NChA7KysmBnZ1fhaxISEhAfH1/tdRIREZFp0fsg6K+//hr9+/dHixYt0KJFC/Tv3x/ffPNNTdRWLT169MDAgQPRsmVLREREYOvWrSgsLMTGjRsrfU1sbKzm7vZFRUU4f/58LVZMREREtU3nAKRWqxEVFYWoqCgcO3YMjRs3RuPGjXH06FFERUVh0KBBFR4fVBlnZ2eYmZkhPz9fqz0/P9+gx+84ODigSZMmOHXqVKV9LC0tYW9vr/UgIiKix5fOAeiTTz7Bzp078eOPP+LEiRP44Ycf8MMPPyA7Oxvff/89duzYgU8++UTnFVtYWKBNmzZISUnRtKnVaqSkpCA0NFS/WVThxo0bOH36NDw8PAw2JhEREelPpRZIO30FmzL/QdrpK1CpH/lmFNWm8zFAq1atwgcffIBevXqVW/b8889j3rx5+OSTTzB+/HidVx4TE4OhQ4ciKCgIwcHBWLBgAW7evKk5K2zIkCFo0KABEhISANw7cPrYsWOaf//zzz/IzMyEra0tGjduDACYOHEievfuDW9vb1y8eBFxcXEwMzNDdHS0znURERGRYSVn5SJ+8zHkFt3WtHkoFYjr3QyRLWp/I4XO9wKzsrJCdnZ2pWdTnT17Fk8++ST+/fdfvQpYtGgRPvjgA+Tl5SEwMBALFy5ESEgIAKBz587w8fHB6tWrAQBnzpyBr69vuTE6deqE1NRUAMCgQYOwZ88eXLlyBS4uLggLC8P777+v10UaeS8wIiIiw0nOysWYdRl4MHDI/v9/lw5ubZAQpM/vt84ByMnJCampqWjZsmWFy48cOYKOHTvi2rVr+ldcxzAAERERGYZKLRA2d5fWlp/7yQC4KxX4bXIXmMllFfbRVY3cDDU0NBRLly6tdPnixYsNeuwOERERmb70nKuVhh8AEAByi24jPad27yeq8zFAU6dORefOnXHlyhVMnDgRTz75JIQQOH78OD788ENs2rQJu3fvrslaiYiIyMQUXK88/FSnn6HoHICeeeYZJCUl4dVXX8W3336rtczR0RFfffUV2rdvb/ACiYiIyHS52ikM2s9Q9LpLaL9+/RAREYFt27bh5MmTAIAmTZqge/fusLa2rpECiYiIyHQF+zrBQ6lAXtHtcgdBA/87BijY16lW69L7NunW1tbo169fhcv++ecfNGjQ4JGLIiIioseDmVyGuN7NMGZdBmSAVggqO+Q5rnezRz4AWl963wqjInl5eRg7diz8/f0NMRwRERE9RiJbeGDp4NZwV2rv5nJXKgx2Cry+dN4CdO3aNbz++uvYsWMHLCwsMGXKFLzxxhuYMWMG5s+fj5YtW2LVqlU1WSsRERGZqMgWHujWzB3pOVdRcP02XO3u7faq7S0/ZXQOQFOmTMHevXsxbNgwbNu2DW+99RaSk5Mhl8uxa9cutGvXribrJCIiIhNnJpch1K++scsAoMcusJ9//hmrVq3C/PnzsXnzZgghEBgYiC1btjD8EBERkUnROQBdvHgRTZs2BQD4+PhAoVBg8ODBNVYYERERUU3ROQAJIWBu/r89ZmZmZrCysqqRooiIiIhqks7HAAkh0LVrV00I+vfff9G7d29YWFho9cvIyDBshUREREQGpnMAiouL03rep08fgxdDREREVBt0vhu8lPBu8ERERKanRu4GT0RERPS4YAAiIiIiydH7XmBERFQ5lVrUmSvdElHlGICIiAwkOSsX8ZuPIbfotqbNQ6lAXO9mRrnXERFV7pF2gV24cAFqtdpQtRARmazkrFyMWZehFX4AIK/oNsasy0ByVq6RKiOiijxSAGrWrBnOnDljoFKIiEyTSi0Qv/kYKjqltqwtfvMxqNQ86ZaornikAMQz6ImIgPScq+W2/NxPAMgtuo30nKu1VxQRVYlngRERPaKC65WHn+r0I6Ka90gB6J133oGTk5OhaiEiMkmudgqD9iOimvdIZ4HFxsYaqg4iIpMV7OsED6UCeUW3KzwOSAbAXXnvlHgiqhu4C4yI6BGZyWWI690MwL2wc7+y53G9m/F6QER1CAMQEZEBRLbwwNLBreGu1N7N5a5UYOng1rwOEFEdwwshEhEZSGQLD3Rr5s4rQROZAAYgIiIDMpPLEOpX39hlENFD6L0LLDk5Gb/99pvm+eLFixEYGIiXXnoJ165dM2hxRERERDVB7wA0adIkFBcXAwCOHDmCCRMmoGfPnsjJyUFMTIzBCyQiIiIyNL13geXk5KBZs3tnO3z77bfo1asXZs+ejYyMDPTs2dPgBRIREREZmt5bgCwsLHDr1i0AwM6dO9G9e3cAgJOTk2bLEBEREVFdpvcWoLCwMMTExKB9+/ZIT09HUlISAOCvv/5Cw4YNDV4gERERkaHpvQVo0aJFMDc3xzfffIOlS5eiQYMGAICff/4ZkZGRBi+QiIiIyNBkgrd0L6e4uBhKpRJFRUWwt7c3djlERESkA31+v3XaBVZcXKwZ6GHH+TAwEBERUV2nUwBydHREbm4uXF1d4eDgAJms/FVNhRCQyWRQqVQGL5KIiIjIkHQKQLt27YKTk5Pm3xUFICIiIiJTwWOAKsBjgIiIiEyPPr/fep8FNmPGDKjV6nLtRUVFiI6O1nc4IiIAgEotkHb6CjZl/oO001egUvO/zYio5uh9HaDPP/8c27dvx7p169CoUSMAQGpqKoYMGQJ3d3eDF0hEj7/krFzEbz6G3KLbmjYPpQJxvZshsoWHESsjoseV3luADh8+jIYNGyIwMBCJiYmYNGkSunfvjldeeQV79+6tiRqJ6DGWnJWLMesytMIPAOQV3caYdRlIzso1UmVE9DjTewuQo6MjNm7ciHfeeQevvfYazM3N8fPPP6Nr1641UR8RPcZUaoH4zcdQ0c4uAUAGIH7zMXRr5g4zOU++ICLD0XsLEAB8+umn+OSTTxAdHY1GjRph3Lhx+PPPPw1dGxE95tJzrpbb8nM/ASC36DbSc67WXlFEJAl6B6DIyEjEx8djzZo1+PLLL3Ho0CF07NgR7dq1w7x582qiRiJ6TBVcrzz8VKcfEZGu9A5AKpUKhw8fxoABAwAAVlZWWLp0Kb755ht8/PHHehewePFi+Pj4QKFQICQkBOnp6ZX2PXr0KF544QX4+PhAJpNhwYIFjzwmERmPq53CoP2IiHSldwDasWMHPD09y7U/99xzOHLkiF5jJSUlISYmBnFxccjIyECrVq0QERGBgoKCCvvfunULjRo1wpw5cyo940zfMYnIeIJ9neChVKCyo3tkuHc2WLCvU22WRUQSYNQLIYaEhKBt27ZYtGgRAECtVsPLywtjx47FlClTqnytj48Pxo8fj/HjxxtszDK8ECJR7Sk7CwyA1sHQZaFo6eDWPBWeiHRSoxdCVKlUmD9/PoKDg+Hu7g4nJyeth65KS0tx8OBBhIeH/68YuRzh4eFIS0vTt6waG5OIalZkCw8sHdwa7krt3VzuSgXDDxHVGL1Pg4+Pj8eKFSswYcIEvPvuu5g6dSrOnDmDH374AdOnT9d5nMuXL0OlUsHNzU2r3c3NDSdOnNC3rEcas6SkBCUlJZrnD7vjPREZVmQLD3Rr5o70nKsouH4brnb3dnvx1Hciqil6B6Avv/wSiYmJeO655zBjxgxER0fDz88PLVu2xL59+zBu3LiaqLNGJSQkID4+3thlEEmamVyGUL/6xi6DHjMqtWCwpgrpHYDy8vLw1FNPAQBsbW1RVFQEAOjVqxemTZum8zjOzs4wMzNDfn6+Vnt+fn61b6lR3TFjY2MRExOjeV5cXAwvL69q1UBERHUDb7FCVdH7GKCGDRsiN/fepen9/Pywfft2AMCBAwdgaWmp8zgWFhZo06YNUlJSNG1qtRopKSkIDQ3Vt6xHGtPS0hL29vZaDyIiMl28xQo9jN4BqF+/fpqAMXbsWEybNg3+/v4YMmQI/vOf/+g1VkxMDBITE7FmzRocP34cY8aMwc2bNzF8+HAAwJAhQxAbG6vpX1paiszMTGRmZqK0tBT//PMPMjMzcerUKZ3HJCKix9vDbrEC3LvFikpttJOgqQ7QexfYnDlzNP+OiorCE088gbS0NPj7+6N37956jRUVFYVLly5h+vTpyMvLQ2BgIJKTkzUHMZ87dw5y+f8y2sWLF/H0009rns+fPx/z589Hp06dkJqaqtOYRET0eNPnFis87ky6jHodoLqK1wEiIjJdmzL/wZsbMh/a75NBgegT2KDmC6JaU6PXAbqfvb09/v7770cZgoiIyKB4ixXShc4B6OLFi+XauPGIiIjqGt5ihXShcwBq3rw51q9fX5O1EBERPTIzuQxxvZsBQLkQVPY8rnczXg9I4nQOQO+//z5ee+01DBw4EFevXgUADB48mMfIEBFRncNbrNDD6HUQdE5ODkaMGIFjx44hMTFR77O+TAUPgiYiejzwStDSos/vt16nwfv6+mLXrl1YtGgR+vfvj6ZNm8LcXHuIjIwM/SsmIiKqAbzFClVG7+sAnT17Ft999x0cHR3Rp0+fcgGIiIiIqK7TK70kJiZiwoQJCA8Px9GjR+Hi4lJTdRERERHVGJ0DUGRkJNLT07Fo0SIMGTKkJmsiIiIiqlE6ByCVSoXDhw+jYcOGNVkPERERUY3TOQDt2LGjJusgIiIiqjWPdCsMIiIiIlPEAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSwwBEREREksMARERERJLDAERERESSUycC0OLFi+Hj4wOFQoGQkBCkp6dX2f/rr7/Gk08+CYVCgaeeegpbt27VWj5s2DDIZDKtR2RkZE1OgYiIiEyI0QNQUlISYmJiEBcXh4yMDLRq1QoREREoKCiosP/evXsRHR2NESNG4NChQ+jbty/69u2LrKwsrX6RkZHIzc3VPL766qvamI4kqNQCaaevYFPmP0g7fQUqtTB2SURERHqRCSGM+usVEhKCtm3bYtGiRQAAtVoNLy8vjB07FlOmTCnXPyoqCjdv3sSWLVs0be3atUNgYCCWLVsG4N4WoMLCQvzwww/Vqqm4uBhKpRJFRUWwt7ev1hiPq+SsXMRvPobcotuaNg+lAnG9myGyhYcRKyMiIqnT5/fbqFuASktLcfDgQYSHh2va5HI5wsPDkZaWVuFr0tLStPoDQERERLn+qampcHV1RUBAAMaMGYMrV65UWkdJSQmKi4u1HlReclYuxqzL0Ao/AJBXdBtj1mUgOSvXSJURERHpx6gB6PLly1CpVHBzc9Nqd3NzQ15eXoWvycvLe2j/yMhIfPHFF0hJScHcuXPxyy+/oEePHlCpVBWOmZCQAKVSqXl4eXk94swePyq1QPzmY6hoc2FZW/zmY9wdRkREJsHc2AXUhEGDBmn+/dRTT6Fly5bw8/NDamoqunbtWq5/bGwsYmJiNM+Li4sZgh6QnnO13Jaf+wkAuUW3kZ5zFaF+9WuvMCIiomow6hYgZ2dnmJmZIT8/X6s9Pz8f7u7uFb7G3d1dr/4A0KhRIzg7O+PUqVMVLre0tIS9vb3Wg7QVXK88/FSnHxERkTEZNQBZWFigTZs2SElJ0bSp1WqkpKQgNDS0wteEhoZq9QeAHTt2VNofAC5cuIArV67Aw4MH6VaXq53CoP2IiIiMyeinwcfExCAxMRFr1qzB8ePHMWbMGNy8eRPDhw8HAAwZMgSxsbGa/m+++SaSk5Px4Ycf4sSJE5gxYwb++OMPvPHGGwCAGzduYNKkSdi3bx/OnDmDlJQU9OnTB40bN0ZERIRR5vg4CPZ1godSAVkly2W4dzZYsK9TbZZFRERULUY/BigqKgqXLl3C9OnTkZeXh8DAQCQnJ2sOdD537hzk8v/ltGeeeQbr16/Hu+++i3feeQf+/v744Ycf0KJFCwCAmZkZDh8+jDVr1qCwsBCenp7o3r07Zs6cCUtLS6PM8XFgJpchrnczjFmXARmgdTB0WSiK690MZvLKIhIREVHdYfTrANVFvA5Q5XgdICIiqqv0+f02+hYgMi2RLTzQrZk70nOuouD6bbja3dvtxS0/RERkShiASG9mchlPdSciIpNm9IOgiYiIiGobAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUkOAxARERFJDgMQERERSQ4DEBEREUmOubELIDIWlVogPecqCq7fhqudAsG+TjCTy4xdlt4el3lQ3cLvVd3Cz8Pw6kQAWrx4MT744APk5eWhVatW+PTTTxEcHFxp/6+//hrTpk3DmTNn4O/vj7lz56Jnz56a5UIIxMXFITExEYWFhWjfvj2WLl0Kf3//2pgOmYDkrFzEbz6G3KLbmjYPpQJxvZshsoWHESvTz+MyD6pb+L2qW/h51Ayj7wJLSkpCTEwM4uLikJGRgVatWiEiIgIFBQUV9t+7dy+io6MxYsQIHDp0CH379kXfvn2RlZWl6TNv3jwsXLgQy5Ytw/79+2FjY4OIiAjcvn27wjFJWpKzcjFmXYbWHxMAyCu6jTHrMpCclWukyvTzuMyD6hZ+r+oWfh41RyaEEMYsICQkBG3btsWiRYsAAGq1Gl5eXhg7diymTJlSrn9UVBRu3ryJLVu2aNratWuHwMBALFu2DEIIeHp6YsKECZg4cSIAoKioCG5ubli9ejUGDRr00JqKi4uhVCpRVFQEe3t7A82U6gKVWiBs7q5yf0zKyAC4KxX4bXKXOr15+XGZB9Ut/F7VLfw89KfP77dRtwCVlpbi4MGDCA8P17TJ5XKEh4cjLS2twtekpaVp9QeAiIgITf+cnBzk5eVp9VEqlQgJCal0zJKSEhQXF2s96PGUnnO10j8mACAA5BbdRnrO1dorqhoel3lQ3cLvVd3Cz6NmGTUAXb58GSqVCm5ublrtbm5uyMvLq/A1eXl5VfYv+199xkxISIBSqdQ8vLy8qjUfqvsKruu2G1TXfsbyuMyD6hZ+r+oWfh41y+jHANUFsbGxKCoq0jzOnz9v7JKohrjaKQzaz1gel3lQ3cLvVd3Cz6NmGTUAOTs7w8zMDPn5+Vrt+fn5cHd3r/A17u7uVfYv+199xrS0tIS9vb3Wgx5Pwb5O8FAqUNnechnunV0R7OtUm2Xp7XGZB9Ut/F7VLfw8apZRA5CFhQXatGmDlJQUTZtarUZKSgpCQ0MrfE1oaKhWfwDYsWOHpr+vry/c3d21+hQXF2P//v2VjknSYSaXIa53MwAo90el7Hlc72Z1/oDCx2UeVLfwe1W38POoWUbfBRYTE4PExESsWbMGx48fx5gxY3Dz5k0MHz4cADBkyBDExsZq+r/55ptITk7Ghx9+iBMnTmDGjBn4448/8MYbbwAAZDIZxo8fj1mzZuHHH3/EkSNHMGTIEHh6eqJv377GmCLVMZEtPLB0cGu4K7U3G7srFVg6uLXJXFfjcZkH1S38XtUt/DxqjtFPgweARYsWaS6EGBgYiIULFyIkJAQA0LlzZ/j4+GD16tWa/l9//TXeffddzYUQ582bV+GFEJcvX47CwkKEhYVhyZIlaNKkiU718DR4aXhcrqz6uMyD6hZ+r+oWfh660ef3u04EoLqGAYiIiMj0mMx1gIiIiIiMgQGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCSHAYiIiIgkhwGIiIiIJIcBiIiIiCTH3NgF1EVlF8cuLi42ciVERESkq7LfbV1ucsEAVIHr168DALy8vIxcCREREenr+vXrUCqVVfbhvcAqoFarcfHiRdjZ2UEmM+zN5oqLi+Hl5YXz58+b9H3GOI+6hfOoWziPuoXzqFtqch5CCFy/fh2enp6Qy6s+yodbgCogl8vRsGHDGl2Hvb29SX+By3AedQvnUbdwHnUL51G31NQ8HrblpwwPgiYiIiLJYQAiIiIiyWEAqmWWlpaIi4uDpaWlsUt5JJxH3cJ51C2cR93CedQtdWUePAiaiIiIJIdbgIiIiEhyGICIiIhIchiAiIiISHIYgIiIiEhyGIB0NGPGDMhkMq3Hk08+qVl++vRp9OvXDy4uLrC3t8eLL76I/Px8rTH++usv9OnTB87OzrC3t0dYWBh279790HUfPnwYHTp0gEKhgJeXF+bNm2dy87h9+zaGDRuGp556Cubm5ujbt2+152DMeaSmpqJPnz7w8PCAjY0NAgMD8eWXX5rcPLKzs/Hss8/Czc0NCoUCjRo1wrvvvos7d+6Y1Dzud+rUKdjZ2cHBwaFaczDmPM6cOVNuvTKZDPv27TOpeQD3rsQ7f/58NGnSBJaWlmjQoAHef/99k5pHReuVyWSwsbExqXkAwLZt29CuXTvY2dnBxcUFL7zwAs6cOWNy89i4cSMCAwNhbW0Nb29vfPDBB9Waw/0YgPTQvHlz5Obmah6//fYbAODmzZvo3r07ZDIZdu3ahd9//x2lpaXo3bs31Gq15vW9evXC3bt3sWvXLhw8eBCtWrVCr169kJeXV+k6i4uL0b17d3h7e+PgwYP44IMPMGPGDCxfvtyk5qFSqWBlZYVx48YhPDy82rUbex579+5Fy5Yt8e233+Lw4cMYPnw4hgwZgi1btpjUPOrVq4chQ4Zg+/btyM7OxoIFC5CYmIi4uDiTmkeZO3fuIDo6Gh06dKh2/XVhHjt37tRad5s2bUxuHm+++SZWrFiB+fPn48SJE/jxxx8RHBxsUvOYOHGi1jpzc3PRrFkzDBw40KTmkZOTgz59+qBLly7IzMzEtm3bcPnyZfTv39+k5vHzzz/j5ZdfxujRo5GVlYUlS5bg448/xqJFi6o9DwCAIJ3ExcWJVq1aVbhs27ZtQi6Xi6KiIk1bYWGhkMlkYseOHUIIIS5duiQAiD179mj6FBcXCwCaPhVZsmSJcHR0FCUlJZq2yZMni4CAAJOax/2GDh0q+vTpU636y9SFeZTp2bOnGD58uP6TEHVrHm+99ZYICwvTfxLC+PN4++23xeDBg8WqVauEUqms1hyMOY+cnBwBQBw6dKjatdeFeRw7dkyYm5uLEydOmPQ8HpSZmVluHFOYx9dffy3Mzc2FSqXStP34449CJpOJ0tJSk5lHdHS0GDBggFbbwoULRcOGDYVardZ7HmW4BUgPJ0+ehKenJxo1aoSXX34Z586dAwCUlJRAJpNpXdRJoVBALpdr0nH9+vUREBCAL774Ajdv3sTdu3fx2WefwdXVtcr/yktLS0PHjh1hYWGhaYuIiEB2djauXbtmMvOoCXVlHkVFRXBycjLpeZw6dQrJycno1KmTyc1j165d+Prrr7F48eJq114X5gEAzz//PFxdXREWFoYff/zR5OaxefNmNGrUCFu2bIGvry98fHwwcuRIXL161aTm8aAVK1agSZMmj7SF0RjzaNOmDeRyOVatWgWVSoWioiKsXbsW4eHhqFevnsnMo6SkBAqFQqvNysoKFy5cwNmzZ6s1DwDcAqSrrVu3io0bN4o///xTJCcni9DQUPHEE0+I4uJiUVBQIOzt7cWbb74pbt68KW7cuCHeeOMNAUC8+uqrmjHOnz8v2rRpI2QymTAzMxMeHh4iIyOjyvV269ZNawwhhDh69KgAII4dO2Yy87ifIbYA1YV5CCFEUlKSsLCwEFlZWSY5j9DQUGFpaakZ8/7/UjSFeVy+fFl4eXmJX375RQghHnkLkLHmcenSJfHhhx+Kffv2ifT0dDF58mQhk8nEpk2bTGoer732mrC0tBQhISFiz549Yvfu3SIwMFA8++yzJjWP+/3777/C0dFRzJ07t1pzMPY8UlNThaurqzAzMxMARGhoqLh27ZpJzeOzzz4T1tbWYufOnUKlUons7Gzx5JNPCgBi79691ZqLEEIwAFXTtWvXhL29vVixYoUQ4t7mv0aNGmk+1MGDB4vWrVuL0aNHCyGEUKvV4vnnnxc9evQQv/32mzh48KAYM2aMaNCggbh48aIQQohmzZoJGxsbYWNjIyIjI4UQhg9AxprH/QwRgOrCPHbt2iWsra3FmjVrTHYe586dE0ePHhXr168XDRo0eKQ/8saYR79+/cTkyZM1633UAGSseVTklVdeqfYuSWPNY9SoUQKAyM7O1qz74MGDAoBBdosZ4/NYv369MDc3F3l5eY9cf23PIzc3V/j7+4tJkyaJjIwM8csvv4hOnTqJrl27PtKuo9qeh1qtFm+//bZQKBTCzMxMODo6ihkzZggAYt++fdWunwHoEQQFBYkpU6ZotV26dEmTrt3c3MS8efOEEELs3Lmz3P5RIYRo3LixSEhIEEIIcebMGXHy5Elx8uRJceHCBSHEvT+CD4aFXbt2CQDi6tWrJjOP+9VEAKrteaSmpgobGxvx2WefmfQ87rd27VphZWUl7t69azLzUCqVwszMTPOQy+UCgDAzMxOff/65ycyjIosWLRLu7u4GmUNtzWP69OnC3Nxc6zW3bt0SAMT27dtNZh7369Kli+jbt69Baq/tebz77rsiKChI6zXnz58XAERaWprJzKPM3bt3xYULF0RJSYnYunWrACAKCgqqXbt59XeeSduNGzdw+vRpvPLKK1rtzs7OAO4dl1BQUIDnn38eAHDr1i0AgFyufdiVXC7XHCHv7e1dbj2hoaGYOnUq7ty5o9lnu2PHDgQEBMDR0dFk5lHTanMeqamp6NWrF+bOnYtXX33VZOfxILVajTt37kCtVsPMzMwk5pGWlgaVSqV5vmnTJsydOxd79+5FgwYNHmkOtTmPimRmZsLDw+OR6i9TW/No37497t69i9OnT8PPzw/AvdOeK+tfV+dRJicnB7t3737k47EeVFvzuHXrVrnXlP1/+/4zs+r6PO6vvez/11999RVCQ0Ph4uJS/QlUOzpJzIQJE0RqaqrIyckRv//+uwgPDxfOzs6a9Lly5UqRlpYmTp06JdauXSucnJxETEyM5vWXLl0S9evXF/379xeZmZkiOztbTJw4UdSrV09kZmZWut7CwkLh5uYmXnnlFZGVlSU2bNggrK2tq73lwVjzEOLerrtDhw6J3r17i86dO4tDhw5V+6wXY82jbLdXbGysyM3N1TyuXLliUvNYt26dSEpKEseOHROnT58WSUlJwtPTU7z88ssmNY8HPeouMGPNY/Xq1WL9+vXi+PHj4vjx4+L9998XcrlcrFy50qTmoVKpROvWrUXHjh1FRkaG+OOPP0RISIjo1q2bSc2jzLvvvis8PT0feauoseaRkpIiZDKZiI+PF3/99Zc4ePCgiIiIEN7e3uLWrVsmM49Lly6JpUuXiuPHj4tDhw6JcePGCYVCIfbv36/3HO7HAKSjqKgo4eHhISwsLESDBg1EVFSUOHXqlGb55MmThZubm6hXr57w9/cXH374Ybl9rAcOHBDdu3cXTk5Ows7OTrRr105s3br1oev+888/RVhYmLC0tBQNGjQQc+bMMcl5eHt7CwDlHqY0j6FDh1Y4h06dOpnUPDZs2CBat24tbG1thY2NjWjWrJmYPXu2+Pfff01qHg961ABkrHmsXr1aNG3aVFhbWwt7e3sRHBwsvv76a5ObhxBC/PPPP6J///7C1tZWuLm5iWHDhlX7PxCMOQ+VSiUaNmwo3nnnnWrVXlfm8dVXX4mnn35a2NjYCBcXF/H888+L48ePm9Q8Ll26JNq1aydsbGyEtbW16Nq16yMd+1NGJoQQ1d9+RERERGR6eB0gIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiIiKSHAYgIiIikhwGICIiIpIcBiAiI0lNTYVMJkNhYaGxS6kzZsyYgcDAwEqX6/KerV69Gg4ODg9d1+eff47u3btrng8bNgx9+/bVvdg6Stf5P+4uX74MV1dXXLhwwdilUB3FAESSplKp8Mwzz6B///5a7UVFRfDy8sLUqVNrbN3PPPMMcnNzoVQqa2wdM2bMgEwmg0wmg5mZGby8vPDqq6/i6tWrNbbOmmSo9+z27duYNm0a4uLiDFRZeTKZDD/88MND+/n4+Gg+o7LHnDlzaqwuY9P1fXlUzs7OGDJkSI1+xmTaGIBI0szMzLB69WokJyfjyy+/1LSPHTsWTk5ONfrH08LCAu7u7pDJZDW2DgBo3rw5cnNzce7cOaxatQrJyckYM2ZMja7zYe7cuVOt1xnqPfvmm29gb2+P9u3bP9I4hvLee+8hNzdX8xg7dqyxSyqnup9ZTdGlnuHDh+PLL7802cBPNYsBiCSvSZMmmDNnDsaOHYvc3Fxs2rQJGzZswBdffAELC4tKXzd58mQ0adIE1tbWaNSoEaZNm6b5oyyEQHh4OCIiIlB2u72rV6+iYcOGmD59OoDyu3POnj2L3r17w9HRETY2NmjevDm2bt36yPMzNzeHu7s7GjRogPDwcAwcOBA7duzQ6rNixQo0bdoUCoUCTz75JJYsWaK1/MKFC4iOjoaTkxNsbGwQFBSE/fv3a5YvXboUfn5+sLCwQEBAANauXav1eplMhqVLl+L555+HjY0N3n//fQDAnDlz4ObmBjs7O4wYMQK3b9+uci4V7QJbvXo1nnjiCVhbW6Nfv364cuXKQ9+TDRs2oHfv3lX2SU5ORlhYGBwcHFC/fn306tULp0+f1iwvLS3FG2+8AQ8PDygUCnh7eyMhIQHAva06ANCvXz/IZDLN88rY2dnB3d1d87Cxsamyf2FhIV577TW4ublBoVCgRYsW2LJli1afbdu2oWnTprC1tUVkZCRyc3M1yw4cOIBu3brB2dkZSqUSnTp1QkZGhtbrK/rMVCoVRowYAV9fX1hZWSEgIACffPJJufpWrlyJ5s2bw9LSEh4eHnjjjTce+r5s2rQJrVu3hkKhQKNGjRAfH4+7d+9WWc+1a9fw8ssvw8XFBVZWVvD398eqVas0r2nevDk8PT3x/fffV/l+kkQ98u1UiR4DarVadO7cWXTt2lW4urqKmTNnPvQ1M2fOFL///rvIyckRP/74o3BzcxNz587VLL9w4YJwdHQUCxYsEEIIMXDgQBEcHCzu3LkjhBBi9+7dAoC4du2aEEKI5557TnTr1k0cPnxYnD59WmzevFn88ssvjzSvuLg40apVK83znJwc0bx5c+Hm5qZpW7dunfDw8BDffvut+Pvvv8W3334rnJycxOrVq4UQQly/fl00atRIdOjQQfz666/i5MmTIikpSezdu1cIIcR3330n6tWrJxYvXiyys7PFhx9+KMzMzMSuXbs06wAgXF1dxcqVK8Xp06fF2bNnRVJSkrC0tBQrVqwQJ06cEFOnThV2dnZa9T7owfds3759Qi6Xi7lz54rs7GzxySefCAcHh4feEV6pVIoNGzZotQ0dOlT06dNH8/ybb74R3377rTh58qQ4dOiQ6N27t3jqqaeESqUSQgjxwQcfCC8vL7Fnzx5x5swZ8euvv4r169cLIYQoKCgQAMSqVatEbm6uKCgoqLQWb29v4ebmJpycnERgYKCYN2+e5jtSEZVKJdq1ayeaN28utm/frvmulN1Re9WqVaJevXoiPDxcHDhwQBw8eFA0bdpUvPTSS5oxUlJSxNq1a8Xx48fFsWPHxIgRI4Sbm5soLi7W9KnoMystLRXTp08XBw4cEH///bdYt26dsLa2FklJSZrXLVmyRCgUCrFgwQKRnZ0t0tPTxccff1zl+7Jnzx5hb28vVq9eLU6fPi22b98ufHx8xIwZM6qs57///a8IDAwUBw4cEDk5OWLHjh3ixx9/1Hq/oqKixNChQyt9P0m6GICI/t/x48cFAPHUU09V+QNUmQ8++EC0adNGq23jxo1CoVCIKVOmCBsbG/HXX39plj34Y/7UU09p/cE3hLi4OCGXy4WNjY1QKBQCgAAgPvroI00fPz8/zQ93mZkzZ4rQ0FAhhBCfffaZsLOzE1euXKlwHc8884wYNWqUVtvAgQNFz549Nc8BiPHjx2v1CQ0NFa+//rpWW0hIiF4BKDo6Wms9Qtz7wasqAF27dk0AEHv27NFqfzAAPejSpUsCgDhy5IgQQoixY8eKLl26CLVaXWF/AOL777+vdLwyH374odi9e7f4888/xdKlS4WDg4N46623Ku2/bds2IZfLRXZ2doXLV61aJQCIU6dOadoWL16sFXofpFKphJ2dndi8ebNW/Q9+ZhX573//K1544QXNc09PTzF16tRK+1f0vnTt2lXMnj1bq23t2rXCw8Ojynp69+4thg8fXmV9b731lujcufPDpkESxF1gRP9v5cqVsLa2Rk5OjtaZI6NHj4atra3mUSYpKQnt27eHu7s7bG1t8e677+LcuXNaYw4cOBD9+vXDnDlzMH/+fPj7+1e6/nHjxmHWrFlo37494uLicPjw4Ur7zp49W6umB9d7v4CAAGRmZuLAgQOYPHkyIiIiNMeY3Lx5E6dPn8aIESO0xps1a5Zmd09mZiaefvppODk5VTj+8ePHyx1L0759exw/flyrLSgoqNzrQkJCtNpCQ0MrnUdl69Z3jH///RcAoFAoqux38uRJREdHo1GjRrC3t9fsril7r4cNG4bMzEwEBARg3Lhx2L59u161l4mJiUHnzp3RsmVLjB49Gh9++CE+/fRTlJSUVNg/MzMTDRs2RJMmTSod09raGn5+fprnHh4eKCgo0DzPz8/HqFGj4O/vD6VSCXt7e9y4caPc9+jBzwwAFi9ejDZt2sDFxQW2trZYvny55nUFBQW4ePEiunbtqtd78Oeff+K9997T+g6OGjUKubm5uHXrVqX1jBkzBhs2bEBgYCDefvtt7N27t9zYVlZWWmMQlWEAIgKwd+9efPzxx9iyZQuCg4MxYsQIzbE77733HjIzMzUPAEhLS8PLL7+Mnj17YsuWLTh06BCmTp2K0tJSrXFv3bqFgwcPwszMDCdPnqyyhpEjR+Lvv//GK6+8giNHjiAoKAiffvpphX1Hjx6tVZOnp2el41pYWKBx48Zo0aIF5syZAzMzM8THxwMAbty4AQBITEzUGi8rKwv79u0DcO8HxBAedlxLbalfvz5kMhmuXbtWZb/evXvj6tWrSExMxP79+zXHPJV9xq1bt0ZOTg5mzpyJf//9Fy+++CIGDBjwyPWFhITg7t27OHPmTIXLdfk86tWrp/VcJpNpvs8AMHToUGRmZuKTTz7B3r17kZmZifr165f7/j74mW3YsAETJ07EiBEjsH37dmRmZmL48OGa11X3u3Ljxg3Ex8drfQePHDmCkydPagXVB+vp0aMHzp49i7feeksTvCZOnKjV5+rVq3BxcalWXfR4YwAiybt16xaGDRuGMWPG4Nlnn8Xnn3+O9PR0LFu2DADg6uqKxo0bax7AvcDk7e2NqVOnIigoCP7+/jh79my5sSdMmAC5XI6ff/4ZCxcuxK5du6qsxcvLC6NHj8Z3332HCRMmIDExscJ+Tk5OWjWZm5vrPN93330X8+fPx8WLF+Hm5gZPT0/8/fffWuM1btwYvr6+AICWLVsiMzOz0jNpmjZtit9//12r7ffff0ezZs2qrKNp06ZaB1ID0IQuXVVnDAsLCzRr1gzHjh2rtM+VK1eQnZ2Nd999F127dkXTpk0rDEz29vaIiopCYmIikpKS8O2332rep3r16kGlUuk1H+DeFh65XA5XV9cKl7ds2RIXLlzAX3/9pffYZX7//XeMGzcOPXv21BysfPnyZZ1e98wzz+D111/H008/jcaNG2sdGG5nZwcfHx+kpKRUOkZF70vr1q2RnZ1d7jvYuHFjyOVV/0y5uLhg6NChWLduHRYsWIDly5drLc/KysLTTz/90LmR9Oj+V5PoMRUbGwshhObaKz4+Ppg/fz4mTpyIHj16VHgGj7+/P86dO4cNGzagbdu2+Omnn8qdafLTTz9h5cqVSEtLQ+vWrTFp0iQMHToUhw8fhqOjY7kxx48fjx49eqBJkya4du0adu/ejaZNmxp8vqGhoWjZsiVmz56NRYsWIT4+HuPGjYNSqURkZCRKSkrwxx9/4Nq1a4iJiUF0dDRmz56Nvn37IiEhAR4eHjh06BA8PT0RGhqKSZMm4cUXX8TTTz+N8PBwbN68Gd999x127txZZR1vvvkmhg0bhqCgILRv3x5ffvkljh49ikaNGuk8l3HjxqF9+/aYP38++vTpg23btiE5Ofmhr4uIiMBvv/2G8ePHV7jc0dER9evXx/Lly+Hh4YFz585hypQpWn0++ugjeHh44Omnn4ZcLsfXX38Nd3d3zUUIy4JA+/btYWlpWeFnnpaWhv379+PZZ5+FnZ0d0tLS8NZbb2Hw4MEV9geATp06oWPHjnjhhRfw0UcfoXHjxjhx4gRkMhkiIyMfOnfg3vd37dq1CAoKQnFxMSZNmqTT1ht/f3988cUX2LZtG3x9fbF27VocOHBAE5aBe9eeGj16NFxdXdGjRw9cv34dv//+u2a3a0Xvy/Tp09GrVy888cQTGDBgAORyOf78809kZWVh1qxZldYzffp0tGnTBs2bN0dJSQm2bNmi9f+Zsi2ws2fP1ul9IYkx8jFIREaVmpoqzMzMxK+//lpuWffu3as8yHXSpEmifv36wtbWVkRFRYmPP/5Yc/BtQUGBcHNz0zqws7S0VLRp00a8+OKLQojyB/S+8cYbws/PT1haWgoXFxfxyiuviMuXLz/S/B48C6zMV199JSwtLcW5c+eEEEJ8+eWXIjAwUFhYWAhHR0fRsWNH8d1332n6nzlzRrzwwgvC3t5eWFtbi6CgILF//37N8iVLlohGjRqJevXqiSZNmogvvvhCa32o5IDg999/Xzg7OwtbW1sxdOhQ8fbbb+t1ELQQQnz++eeiYcOGwsrKSvTu3VvMnz//oWeBHT16VFhZWYnCwkJN24MHQe/YsUM0bdpUWFpaipYtW4rU1FSteSxfvlwEBgYKGxsbYW9vL7p27SoyMjI0r//xxx9F48aNhbm5ufD29q6wjoMHD4qQkBChVCqFQqEQTZs2FbNnzxa3b9+usv4rV66I4cOHi/r16wuFQiFatGghtmzZIoS4dxD0g/P//vvvxf1/7jMyMkRQUJBQKBTC399ffP3118Lb21tztpYQFX9mt2/fFsOGDRNKpVI4ODiIMWPGiClTppT7zJYtWyYCAgJEvXr1hIeHhxg7duxD35fk5GTxzDPPCCsrK2Fvby+Cg4PF8uXLq6xn5syZomnTpsLKyko4OTmJPn36iL///luzfP369SIgIKDK95KkSybEfTuGiYgkYuDAgWjdujViY2ONXQrVkHbt2mHcuHF46aWXjF0K1UE8BoiIJOmDDz7QOquPHi+XL19G//79ER0dbexSqI7iFiAiIiKSHG4BIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyWEAIiIiIslhACIiIiLJYQAiIiIiyfk/BorAUYumI2MAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 38
   },
   {
    "cell_type": "markdown",
@@ -1010,16 +1714,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:18.076272Z",
+     "start_time": "2024-09-18T11:06:18.073837Z"
+    }
+   },
    "source": [
     "if not use_cpd:\n",
     "    factsheets_url = \"https://dataplatform.cloud.ibm.com/wx/prompt-details/{}/factsheet?context=wx&project_id={}\".format(project_pta_id, project_id)\n",
     "else:\n",
     "    factsheets_url = factsheets_url = \"{}/wx/prompt-details/{}/factsheet?context=wx&project_id={}\".format(WML_CREDENTIALS[\"url\"],project_pta_id, project_id)\n",
     "print(\"User can navigate to the published facts in project {}\".format(factsheets_url))"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User can navigate to the published facts in project https://dataplatform.cloud.ibm.com/wx/prompt-details/e78d036b-a8dc-4989-80b5-d17073df6ec5/factsheet?context=wx&project_id=05add4b4-4c47-47c4-a6b6-e6b925ee748c\n"
+     ]
+    }
+   ],
+   "execution_count": 39
   },
   {
    "cell_type": "markdown",
@@ -1060,9 +1777,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:25.687928Z",
+     "start_time": "2024-09-18T11:06:21.148899Z"
+    }
+   },
    "source": [
     "headers={}\n",
     "headers[\"Content-Type\"] = \"application/json\"\n",
@@ -1085,7 +1805,20 @@
     "json_data = response.json()\n",
     "space_pta_id = json_data[\"metadata\"][\"asset_id\"]\n",
     "space_pta_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'d47aaf8c-0c3c-4af6-b5c2-99b61df22f5c'"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 40
   },
   {
    "cell_type": "markdown",
@@ -1103,13 +1836,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T11:06:58.724302Z",
+     "start_time": "2024-09-18T11:06:57.059799Z"
+    }
+   },
    "source": [
     "DEPLOYMENTS_URL = WML_CREDENTIALS[\"url\"] + \"/ml/v4/deployments\"\n",
     "\n",
-    "serving_name = \"<EDIT_THIS>\" # eg: summary_deployment\n",
+    "serving_name = \"<EDIT THIS>\" # eg: summary_deployment\n",
     "\n",
     "payload = {\n",
     "    \"prompt_template\": {\n",
@@ -1141,7 +1877,17 @@
     "    print(deployment_id)\n",
     "else:\n",
     "    print(json_data)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c44fac44-1f0d-4fa8-b541-ec4420bcddcc\n"
+     ]
+    }
+   ],
+   "execution_count": 41
   },
   {
    "cell_type": "markdown",
@@ -1153,10 +1899,29 @@
    ]
   },
   {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:29:49.534620Z",
+     "start_time": "2024-09-18T13:29:49.532173Z"
+    }
+   },
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "source": [
+    "space_pta_id = 'd47aaf8c-0c3c-4af6-b5c2-99b61df22f5c'\n",
+    "space_id = \"bc592530-1cf0-4e56-9fab-70e0924f6907\"\n",
+    "deployment_id = \"c44fac44-1f0d-4fa8-b541-ec4420bcddcc\""
+   ],
    "outputs": [],
+   "execution_count": 42
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:30:03.327669Z",
+     "start_time": "2024-09-18T13:29:51.249840Z"
+    }
+   },
+   "cell_type": "code",
    "source": [
     "label_column = \"reference_summary\"\n",
     "operational_space_id = \"production\"\n",
@@ -1224,7 +1989,7 @@
     "}\n",
     "\n",
     "\n",
-    "response = wos_client.monitor_instances.mrm.execute_prompt_setup(prompt_template_asset_id = space_pta_id, \n",
+    "response = wos_client.wos.execute_prompt_setup(prompt_template_asset_id = space_pta_id, \n",
     "                                                                   space_id = space_id,\n",
     "                                                                   deployment_id = deployment_id,\n",
     "                                                                   label_column = label_column, \n",
@@ -1236,29 +2001,95 @@
     "\n",
     "result = response.result\n",
     "result._to_dict()"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "=============================================================================\n",
+      "\n",
+      " Waiting for end of adding prompt setup d47aaf8c-0c3c-4af6-b5c2-99b61df22f5c \n",
+      "\n",
+      "=============================================================================\n",
+      "\n",
+      "\n",
+      "\n",
+      "finished\n",
+      "\n",
+      "---------------------------------------------------------------\n",
+      " Successfully finished setting up prompt template subscription \n",
+      "---------------------------------------------------------------\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'prompt_template_asset_id': 'd47aaf8c-0c3c-4af6-b5c2-99b61df22f5c',\n",
+       " 'space_id': 'bc592530-1cf0-4e56-9fab-70e0924f6907',\n",
+       " 'deployment_id': 'c44fac44-1f0d-4fa8-b541-ec4420bcddcc',\n",
+       " 'service_provider_id': '5b713673-eb35-4ba0-9ab3-a850ee426079',\n",
+       " 'subscription_id': 'b77388db-fbd8-4285-8d72-8b1e17621439',\n",
+       " 'mrm_monitor_instance_id': '01d06467-3bc7-4809-9127-415b8d1522a8',\n",
+       " 'start_time': '2024-09-18T13:29:54.726312Z',\n",
+       " 'end_time': '2024-09-18T13:30:01.204596Z',\n",
+       " 'status': {'state': 'FINISHED'}}"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 43
   },
   {
-   "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "With the below cell, users can read the prompt setup task and check its status"
-   ]
+   "cell_type": "markdown",
+   "source": "With the below cell, users can read the prompt setup task and check its status"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:30:08.815825Z",
+     "start_time": "2024-09-18T13:30:08.064177Z"
+    }
+   },
    "source": [
-    "response = wos_client.monitor_instances.mrm.get_prompt_setup(prompt_template_asset_id = space_pta_id,\n",
+    "response = wos_client.wos.get_prompt_setup(prompt_template_asset_id = space_pta_id,\n",
     "                                                             deployment_id = deployment_id,\n",
     "                                                             space_id = space_id)\n",
     "\n",
     "result = response.result\n",
     "result_json = result._to_dict()\n",
     "result_json"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'prompt_template_asset_id': 'd47aaf8c-0c3c-4af6-b5c2-99b61df22f5c',\n",
+       " 'space_id': 'bc592530-1cf0-4e56-9fab-70e0924f6907',\n",
+       " 'deployment_id': 'c44fac44-1f0d-4fa8-b541-ec4420bcddcc',\n",
+       " 'service_provider_id': '5b713673-eb35-4ba0-9ab3-a850ee426079',\n",
+       " 'subscription_id': 'b77388db-fbd8-4285-8d72-8b1e17621439',\n",
+       " 'mrm_monitor_instance_id': '01d06467-3bc7-4809-9127-415b8d1522a8',\n",
+       " 'start_time': '2024-09-18T13:29:54.726312Z',\n",
+       " 'end_time': '2024-09-18T13:30:01.204596Z',\n",
+       " 'status': {'state': 'FINISHED'}}"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 44
   },
   {
    "cell_type": "markdown",
@@ -1271,13 +2102,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:30:11.103356Z",
+     "start_time": "2024-09-18T13:30:11.100177Z"
+    }
+   },
    "source": [
     "prod_subscription_id = result_json[\"subscription_id\"]\n",
     "prod_subscription_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'b77388db-fbd8-4285-8d72-8b1e17621439'"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 45
   },
   {
    "cell_type": "markdown",
@@ -1295,9 +2142,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:30:13.871018Z",
+     "start_time": "2024-09-18T13:30:13.038830Z"
+    }
+   },
    "source": [
     "sub_details = wos_client.subscriptions.get(prod_subscription_id).result\n",
     "sub_details = sub_details._to_dict()\n",
@@ -1308,7 +2158,17 @@
     "if use_cpd:\n",
     "    scoring_url = WML_CREDENTIALS[\"url\"] + \"/ml/v1-beta/deployments/\"+ deployment_id +\"/generation/text?version=2023-09-07\"\n",
     "print(scoring_url)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://us-south.ml.cloud.ibm.com/ml/v1/deployments/c44fac44-1f0d-4fa8-b541-ec4420bcddcc/text/generation?version=2023-09-07\n"
+     ]
+    }
+   ],
+   "execution_count": 46
   },
   {
    "cell_type": "markdown",
@@ -1321,9 +2181,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:44:27.381915Z",
+     "start_time": "2024-09-18T13:33:07.499194Z"
+    }
+   },
    "source": [
     "import csv\n",
     "\n",
@@ -1356,7 +2219,109 @@
     "        pl_data.append(record)\n",
     "    \n",
     "pl_data"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'request': {'parameters': {'template_variables': {'original_text': 'by using our services you are agreeing to these terms our trainer guidelines and our privacy policy. if you are the parent or legal guardian of a child under the age of 13 the parent you are agreeing to these terms on behalf of yourself and your child ren who are authorized to use the services pursuant to these terms and in our privacy policy. if you don t agree to these terms our trainer guidelines and our privacy policy do not use the services.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:34:52.117Z',\n",
+       "   'results': [{'generated_text': 'agree to these terms',\n",
+       "     'generated_token_count': 5,\n",
+       "     'input_token_count': 107,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}},\n",
+       " {'request': {'parameters': {'template_variables': {'original_text': 'if you want to use certain features of the services you will have to create an account with us an account. you can create an account if you have a a pre existing google account b a pre existing pok\\\\u00e9mon trainer club ptc account c a pre existing account with facebook or d such other pre existing third party accounts as we may choose to support in the future notification of which will be provided by allowing selection of such pre existing accounts on the relevant account creation screen. we will create your account by extracting from your google ptc facebook or other pre existing third party account certain personal information such as your email address that your privacy settings on the applicable account permit us to access. it s important that you provide us with accurate complete and up to date information for your account and you agree to update such information as needed to keep it accurate complete and up to date. if you don t we might have to suspend or terminate your account. you agree that you won t disclose your account password to anyone and you ll notify us immediately of any unauthorized use of your account. you re responsible for all activities that occur under your account whether or not you know about them. registration by childrenwe comply with the children s online privacy protection act coppa through the verification and consent process handled by ptc. if you are over the age of 13 and register to create an account through ptc ptc will enable you to access and use the services. the parent of each child under the age of 13 must register with the pok\\\\u00e9mon company international inc tpci through ptc before a child may use the services. tpci requires the parent to verify that he or she is the parent of the child and to consent to the creation of an account with us for the child. upon receipt of both parental verification and consent tpci will enable the parent to create an account with us for the child. if a parent does not consent to a child s access to and use of the services or does not verify the parent s consent through the consent process niantic will bar that child s registration for an account prevent the child s access to and use of the services and ensure that such child s information is not accessible through the services. if a parent has consented to a child s access to and use of the services but wishes to rescind such consent the parent should contact us at https pokemongo nianticlabs com support delete en to submit the request. we will discontinue that child s access to and use of the services and ensure that such child s information is no longer accessible through the services. parents of children under the age of 13 understand and agree that tpci and or niantic may provide information submitted to tpci and or niantic or collected via the services to third parties who use such information for the sole purpose of administering or providing services e g third party security monitoring services and web hosting companies. please see our privacy policy available athttp www nianticlabs com privacy pokemongo en for more information on how we collect use and disclose information from our users.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:36:08.151Z',\n",
+       "   'results': [{'generated_text': 'create an account',\n",
+       "     'generated_token_count': 4,\n",
+       "     'input_token_count': 711,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}},\n",
+       " {'request': {'parameters': {'template_variables': {'original_text': 'during game play please be aware of your surroundings and play safely. you agree that your use of the app and play of the game is at your own risk and it is your responsibility to maintain such health liability hazard personal injury medical life and other insurance policies as you deem reasonably necessary for any injuries that you may incur while using the services. you also agree not to use the app to violate any applicable law rule or regulation including but not limited to the laws of trespass or the trainer guidelines and you agree not to encourage or enable any other individual to violate any applicable law rule or regulation or the trainer guidelines. without limiting the foregoing you agree that in conjunction with your use of the app you will not inflict emotional distress on other people will not humiliate other people publicly or otherwise will not assault or threaten other people will not enter onto private property without permission will not impersonate any other person or misrepresent your affiliation title or authority and will not otherwise engage in any activity that may result in injury death property damage and or liability of any kind. to the extent permitted by applicable law niantic the pok\\\\u00e9mon company tpc and tpci disclaim all liability related to any property damage personal injury or death that may occur during your use of our services including any claims based on the violation of any applicable law rule or regulation or your alleged negligence or other tort liability. further in the event that you have a dispute with one or more other users of the app you release niantic tpc and tpci and our officers directors agents subsidiaries joint ventures and employees from all claims demands and damages actual and consequential of every kind and nature known and unknown suspected and unsuspected disclosed and undisclosed arising out of or in any way connected with such disputes.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:37:18.601Z',\n",
+       "   'results': [{'generated_text': 'be safe',\n",
+       "     'generated_token_count': 3,\n",
+       "     'input_token_count': 393,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}},\n",
+       " {'request': {'parameters': {'template_variables': {'original_text': 'subject to your compliance with these terms niantic grants you a limited nonexclusive nontransferable non sublicensable license to download and install a copy of the app on a mobile device and to run such copy of the app solely for your own personal noncommercial purposes. except as expressly permitted in these terms you may not a copy modify or create derivative works based on the app b distribute transfer sublicense lease lend or rent the app to any third party c reverse engineer decompile or disassemble the app or d make the functionality of the app available to multiple users through any means. niantic reserves all rights in and to the app not expressly granted to you under these terms. if you accessed or downloaded the app from the apple store then you agree to use the app only a on an apple branded product or device that runs ios apple s proprietary operating system software and b as permitted by the usage rules set forth in the apple store terms of service. if you accessed or downloaded the app from any app store or distribution platform like the apple store google play or amazon appstore each an app provider then you acknowledge and agree that these terms are concluded between you and niantic and not with app provider and that as between us and the app provider niantic is solely responsible for the app. app provider has no obligation to furnish any maintenance and support services with respect to the app. in the event of any failure of the app to conform to any applicable warranty you may notify app provider and app provider will refund the purchase price for the app to you if applicable and to the maximum extent permitted by applicable law app provider will have no other warranty obligation whatsoever with respect to the app. any other claims losses liabilities damages costs or expenses attributable to any failure of an app to conform to any warranty will be the sole responsibility of niantic. app provider is not responsible for addressing any claims you have or any claims of any third party relating to the app or your possession and use of the app including but not limited to i product liability claims ii any claim that the app fails to conform to any applicable legal or regulatory requirement and iii claims arising under consumer protection or similar legislation. in the event of any third party claim that the app or your possession and use of the app infringes that third party s intellectual property rights niantic will be solely responsible for the investigation defense settlement and discharge of any such intellectual property infringement claim to the extent required by these terms. app provider and its subsidiaries are third party beneficiaries of these terms as related to your license of the app and that upon your acceptance of the terms and conditions of these terms app provider will have the right and will be deemed to have accepted the right to enforce these terms as related to your license of the app against you as a third party beneficiary thereof. you must also comply with all applicable third party terms of service when using the app. you agree to comply with all u s and foreign export laws and regulations to ensure that neither the app nor any technical data related thereto nor any direct product thereof is exported or re exported directly or indirectly in violation of or used for any purposes prohibited by such laws and regulations. by using the app you represent and warrant that i you are not located in a country that is subject to a u s government embargo or that has been designated by the u s government as a terrorist supporting country and ii you are not listed on any u s government list of prohibited or restricted parties.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:38:44.380Z',\n",
+       "   'results': [{'generated_text': 'license',\n",
+       "     'generated_token_count': 2,\n",
+       "     'input_token_count': 762,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}},\n",
+       " {'request': {'parameters': {'template_variables': {'original_text': 'for purposes of these terms a content means the text software scripts graphics photos sounds music videos audiovisual combinations interactive features works of authorship of any kind and information or other materials that are posted generated provided or otherwise made available through the services and b user content means any content that account holders including you provide to be made available through the services. content includes without limitation user content. subject to your compliance with these terms niantic grants you a personal noncommercial nonexclusive nontransferable non sublicensable revocable license to download view display and use the content solely in connection with your permitted use of the services. content ownershipniantic does not claim any ownership rights in any user content and nothing in these terms will be deemed to restrict any rights that you may have to use and exploit your user content. subject to the foregoing niantic and its licensors including tpc and tpci exclusively own all right title and interest in and to the services and content including all associated intellectual property rights. you acknowledge that the services and content are protected by copyright trademark and other laws of the united states and foreign countries. you agree not to remove alter or obscure any copyright trademark service mark or other proprietary rights notices incorporated in or accompanying the services or content. rights granted by youby making any user content available through services you grant to niantic a nonexclusive perpetual irrevocable transferable sublicensable worldwide royalty free license to use copy modify create derivative works based upon publicly display publicly perform and distribute your user content in connection with operating and providing the services and content to you and to other account holders. you are solely responsible for all your user content. you represent and warrant that you own all your user content or you have all rights that are necessary to grant us the license rights in your user content under these terms. you also represent and warrant that neither your user content nor your use and provision of your user content to be made available through the services nor any use of your user content by niantic on or through the services will infringe misappropriate or violate a third party s intellectual property rights or rights of publicity or privacy or result in the violation of any applicable law or regulation. niantic may reject any submissions in which niantic believes in its sole discretion that the user content is inappropriate or violates the trainer guidelines or these terms. niantic further reserves the right to remove any user content from the services at any time and without notice and for any reason.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:40:21.630Z',\n",
+       "   'results': [{'generated_text': 'license to content',\n",
+       "     'generated_token_count': 4,\n",
+       "     'input_token_count': 539,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}},\n",
+       " {'request': {'parameters': {'template_variables': {'original_text': 'the app permits account holders to capture and trade virtual items including but not limited to pok\\\\u00e9mon characters or creatures trading items during gameplay. unlike virtual money and virtual goods see below trading items are obtained at no additional charge during gameplay. trading items are a category of content and niantic grants you a limited nontransferable non sublicensable revocable license to use such trading items in conjunction with your personal noncommercial use of the services. you acknowledge that you do not acquire any ownership rights in or to trading items and that trading items do not have monetary value. trading items may be traded with other account holders for other trading items but trading items can never be sold transferred or exchanged for virtual money virtual goods real goods real money or real services or any other compensation or consideration from us or anyone else. you also agree that you will only obtain trading items from other account holders and through means provided by us and not from or through any third party platform exchange broker or other mechanism unless expressly authorized. we may cancel any trading items sold transferred or exchanged in violation of these terms. any such sale transfer or exchange or attempt to do so is prohibited and may result in the termination of your account. as set forth below all trading items and other content are provided as is without any warranty.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:41:37.464Z',\n",
+       "   'results': [{'generated_text': 'trading items',\n",
+       "     'generated_token_count': 3,\n",
+       "     'input_token_count': 281,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}},\n",
+       " {'request': {'parameters': {'template_variables': {'original_text': 'we may cancel suspend or terminate your account and your access to your trading items virtual money virtual goods the content or the services in our sole discretion and without prior notice including if a your account is inactive i e not used or logged into for one year b you fail to comply with these terms c we suspect fraud or misuse by you of trading items virtual money virtual goods or other content d we suspect any other unlawful activity associated with your account or e we are acting to protect the services our systems the app any of our users or the reputation of niantic tpc or tpci. we have no obligation or responsibility to and will not reimburse or refund you for any trading items virtual money or virtual goods lost due to such cancellation suspension or termination. you acknowledge that niantic is not required to provide a refund for any reason and that you will not receive money or other compensation for unused virtual money and virtual goods when your account is closed whether such closure was voluntary or involuntary. we have the right to offer modify eliminate and or terminate trading items virtual money virtual goods the content and or the services or any portion thereof at any time without notice or liability to you. if we discontinue the use of virtual money or virtual goods we will provide at least 60 days advance notice to you by posting a notice on the site or app or through other communications.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:42:47.161Z',\n",
+       "   'results': [{'generated_text': 'Cancellation Suspension and Termination',\n",
+       "     'generated_token_count': 11,\n",
+       "     'input_token_count': 299,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}},\n",
+       " {'request': {'parameters': {'template_variables': {'original_text': 'don t be a jerk. don t hack or cheat. we don t have to ban you but we can. we ll also cooperate with law enforcement.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:43:53.073Z',\n",
+       "   'results': [{'generated_text': 'be nice.',\n",
+       "     'generated_token_count': 4,\n",
+       "     'input_token_count': 47,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}},\n",
+       " {'request': {'parameters': {'template_variables': {'original_text': 'give us feedback and we can do whatever we want with it.'}}},\n",
+       "  'response': {'model_id': 'google/flan-ul2',\n",
+       "   'created_at': '2024-09-18T13:44:27.255Z',\n",
+       "   'results': [{'generated_text': 'if you want to give us feedback, you can do so by clicking on the feedback button.',\n",
+       "     'generated_token_count': 21,\n",
+       "     'input_token_count': 22,\n",
+       "     'stop_reason': 'eos_token'}],\n",
+       "   'system': {'warnings': [{'message': 'This model is a Non-IBM Product governed by a third-party license that may impose use restrictions and other obligations. By using this model you agree to its terms as identified in the following URL.',\n",
+       "      'id': 'disclaimer_warning',\n",
+       "      'more_info': 'https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models.html?context=wx'}]}}}]"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 47
   },
   {
    "cell_type": "markdown",
@@ -1374,16 +2339,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:44:44.032745Z",
+     "start_time": "2024-09-18T13:44:44.029743Z"
+    }
+   },
    "source": [
     "import copy\n",
     "\n",
     "additional_pl_data = copy.copy(pl_data)\n",
     "additional_pl_data *= 10\n",
     "print(\"Generated {} additional payload data\".format(len(additional_pl_data)))"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 90 additional payload data\n"
+     ]
+    }
+   ],
+   "execution_count": 48
   },
   {
    "cell_type": "markdown",
@@ -1396,9 +2374,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:44:55.738562Z",
+     "start_time": "2024-09-18T13:44:48.954046Z"
+    }
+   },
    "source": [
     "import time\n",
     "from ibm_watson_openscale.supporting_classes.enums import *\n",
@@ -1412,7 +2393,17 @@
     "    print(\"Payload data set not found. Please check subscription status.\")\n",
     "else:\n",
     "    print(\"Payload data set id: \", payload_data_set_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Payload data set id:  27ac3d88-c630-47e9-86fc-c68497da1539\n"
+     ]
+    }
+   ],
+   "execution_count": 49
   },
   {
    "cell_type": "markdown",
@@ -1423,15 +2414,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:45:20.595367Z",
+     "start_time": "2024-09-18T13:44:57.368185Z"
+    }
+   },
    "source": [
     "wos_client.data_sets.store_records(data_set_id=payload_data_set_id, request_body=additional_pl_data,background_mode=False)\n",
     "time.sleep(5)\n",
     "pl_records_count = wos_client.data_sets.get_records_count(payload_data_set_id)\n",
     "print(\"Number of records in the payload logging table: {}\".format(pl_records_count))"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "==========================================================================================\n",
+      "\n",
+      " Waiting for end of storing records with request id: d384b44e-76cd-4ce7-888f-e448f68ac305 \n",
+      "\n",
+      "==========================================================================================\n",
+      "\n",
+      "\n",
+      "\n",
+      "pending\n",
+      "active\n",
+      "\n",
+      "---------------------------------------\n",
+      " Successfully finished storing records \n",
+      "---------------------------------------\n",
+      "\n",
+      "\n",
+      "Number of records in the payload logging table: 110\n"
+     ]
+    }
+   ],
+   "execution_count": 50
   },
   {
    "cell_type": "markdown",
@@ -1442,9 +2464,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:45:32.120665Z",
+     "start_time": "2024-09-18T13:45:25.988307Z"
+    }
+   },
    "source": [
     "import uuid\n",
     "from ibm_watson_openscale.supporting_classes.payload_record import PayloadRecord\n",
@@ -1457,7 +2482,17 @@
     "    time.sleep(5)\n",
     "    pl_records_count = wos_client.data_sets.get_records_count(payload_data_set_id)\n",
     "    print(\"Number of records in the payload logging table: {}\".format(pl_records_count))"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of records in the payload logging table: 110\n"
+     ]
+    }
+   ],
+   "execution_count": 51
   },
   {
    "cell_type": "markdown",
@@ -1470,9 +2505,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:45:40.188311Z",
+     "start_time": "2024-09-18T13:45:34.186045Z"
+    }
+   },
    "source": [
     "import time\n",
     "from ibm_watson_openscale.supporting_classes.enums import *\n",
@@ -1486,7 +2524,17 @@
     "    print(\"Feedback data set not found. Please check subscription status.\")\n",
     "else:\n",
     "    print(\"Feedback data set id: \", feedback_data_set_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feedback data set id:  2cddbf74-bf63-4649-9661-8b04e14ca096\n"
+     ]
+    }
+   ],
+   "execution_count": 52
   },
   {
    "cell_type": "markdown",
@@ -1497,14 +2545,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:47:45.093273Z",
+     "start_time": "2024-09-18T13:47:45.087340Z"
+    }
+   },
    "source": [
     "import csv\n",
     "\n",
     "test_data_content = []\n",
-    "csv_file_path = \"summarisation.csv\"\n",
+    "csv_file_path = \"summarisation1.csv\"\n",
     "\n",
     "with open(csv_file_path, 'r') as csv_file:\n",
     "    csv_reader = csv.DictReader(csv_file)\n",
@@ -1515,19 +2566,32 @@
     "        result_row = [row[key] for key in feature_fields if key in row]\n",
     "        result_row.append(row[label_column])\n",
     "        result_row.append(prediction_val)\n",
-    "\n",
     "        test_data_content.append(result_row)\n",
+    "\n",
     "if len(test_data_content) == 10: # 10 records are there in the downloaded CSV\n",
     "    print(\"generated feedback data from CSV\")\n",
     "else:\n",
     "    print(\"Failed to generated feedback data from CSV, Kindly verify the CSV file content\")"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "generated feedback data from CSV\n"
+     ]
+    }
+   ],
+   "execution_count": 53
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:48:30.997651Z",
+     "start_time": "2024-09-18T13:48:30.993429Z"
+    }
+   },
    "source": [
     "fields = feature_fields\n",
     "fields.append(label_column)\n",
@@ -1539,7 +2603,50 @@
     "    }\n",
     "]\n",
     "feedback_data"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'fields': ['original_text', 'reference_summary', '_original_prediction'],\n",
+       "  'values': [['by using our services you are agreeing to these terms our trainer guidelines and our privacy policy. if you are the parent or legal guardian of a child under the age of 13 the parent you are agreeing to these terms on behalf of yourself and your child ren who are authorized to use the services pursuant to these terms and in our privacy policy. if you don t agree to these terms our trainer guidelines and our privacy policy do not use the services.',\n",
+       "    'by playing this game you agree to these terms. if you re under 13 and playing your parent guardian agrees on your behalf.',\n",
+       "    'agree to these terms'],\n",
+       "   ['if you want to use certain features of the services you will have to create an account with us an account. you can create an account if you have a a pre existing google account b a pre existing pok\\\\u00e9mon trainer club ptc account c a pre existing account with facebook or d such other pre existing third party accounts as we may choose to support in the future notification of which will be provided by allowing selection of such pre existing accounts on the relevant account creation screen. we will create your account by extracting from your google ptc facebook or other pre existing third party account certain personal information such as your email address that your privacy settings on the applicable account permit us to access. it s important that you provide us with accurate complete and up to date information for your account and you agree to update such information as needed to keep it accurate complete and up to date. if you don t we might have to suspend or terminate your account. you agree that you won t disclose your account password to anyone and you ll notify us immediately of any unauthorized use of your account. you re responsible for all activities that occur under your account whether or not you know about them. registration by childrenwe comply with the children s online privacy protection act coppa through the verification and consent process handled by ptc. if you are over the age of 13 and register to create an account through ptc ptc will enable you to access and use the services. the parent of each child under the age of 13 must register with the pok\\\\u00e9mon company international inc tpci through ptc before a child may use the services. tpci requires the parent to verify that he or she is the parent of the child and to consent to the creation of an account with us for the child. upon receipt of both parental verification and consent tpci will enable the parent to create an account with us for the child. if a parent does not consent to a child s access to and use of the services or does not verify the parent s consent through the consent process niantic will bar that child s registration for an account prevent the child s access to and use of the services and ensure that such child s information is not accessible through the services. if a parent has consented to a child s access to and use of the services but wishes to rescind such consent the parent should contact us at https pokemongo nianticlabs com support delete en to submit the request. we will discontinue that child s access to and use of the services and ensure that such child s information is no longer accessible through the services. parents of children under the age of 13 understand and agree that tpci and or niantic may provide information submitted to tpci and or niantic or collected via the services to third parties who use such information for the sole purpose of administering or providing services e g third party security monitoring services and web hosting companies. please see our privacy policy available athttp www nianticlabs com privacy pokemongo en for more information on how we collect use and disclose information from our users.',\n",
+       "    'you have to use google pokemon trainer club or facebook to sign up and play. if you re under 13 your parent guardian has to do this for you. we might ban your account if your information is inaccurate.',\n",
+       "    'create an account'],\n",
+       "   ['during game play please be aware of your surroundings and play safely. you agree that your use of the app and play of the game is at your own risk and it is your responsibility to maintain such health liability hazard personal injury medical life and other insurance policies as you deem reasonably necessary for any injuries that you may incur while using the services. you also agree not to use the app to violate any applicable law rule or regulation including but not limited to the laws of trespass or the trainer guidelines and you agree not to encourage or enable any other individual to violate any applicable law rule or regulation or the trainer guidelines. without limiting the foregoing you agree that in conjunction with your use of the app you will not inflict emotional distress on other people will not humiliate other people publicly or otherwise will not assault or threaten other people will not enter onto private property without permission will not impersonate any other person or misrepresent your affiliation title or authority and will not otherwise engage in any activity that may result in injury death property damage and or liability of any kind. to the extent permitted by applicable law niantic the pok\\\\u00e9mon company tpc and tpci disclaim all liability related to any property damage personal injury or death that may occur during your use of our services including any claims based on the violation of any applicable law rule or regulation or your alleged negligence or other tort liability. further in the event that you have a dispute with one or more other users of the app you release niantic tpc and tpci and our officers directors agents subsidiaries joint ventures and employees from all claims demands and damages actual and consequential of every kind and nature known and unknown suspected and unsuspected disclosed and undisclosed arising out of or in any way connected with such disputes.',\n",
+       "    'don t die or hurt others and if you do it s not our fault.',\n",
+       "    'be safe'],\n",
+       "   ['subject to your compliance with these terms niantic grants you a limited nonexclusive nontransferable non sublicensable license to download and install a copy of the app on a mobile device and to run such copy of the app solely for your own personal noncommercial purposes. except as expressly permitted in these terms you may not a copy modify or create derivative works based on the app b distribute transfer sublicense lease lend or rent the app to any third party c reverse engineer decompile or disassemble the app or d make the functionality of the app available to multiple users through any means. niantic reserves all rights in and to the app not expressly granted to you under these terms. if you accessed or downloaded the app from the apple store then you agree to use the app only a on an apple branded product or device that runs ios apple s proprietary operating system software and b as permitted by the usage rules set forth in the apple store terms of service. if you accessed or downloaded the app from any app store or distribution platform like the apple store google play or amazon appstore each an app provider then you acknowledge and agree that these terms are concluded between you and niantic and not with app provider and that as between us and the app provider niantic is solely responsible for the app. app provider has no obligation to furnish any maintenance and support services with respect to the app. in the event of any failure of the app to conform to any applicable warranty you may notify app provider and app provider will refund the purchase price for the app to you if applicable and to the maximum extent permitted by applicable law app provider will have no other warranty obligation whatsoever with respect to the app. any other claims losses liabilities damages costs or expenses attributable to any failure of an app to conform to any warranty will be the sole responsibility of niantic. app provider is not responsible for addressing any claims you have or any claims of any third party relating to the app or your possession and use of the app including but not limited to i product liability claims ii any claim that the app fails to conform to any applicable legal or regulatory requirement and iii claims arising under consumer protection or similar legislation. in the event of any third party claim that the app or your possession and use of the app infringes that third party s intellectual property rights niantic will be solely responsible for the investigation defense settlement and discharge of any such intellectual property infringement claim to the extent required by these terms. app provider and its subsidiaries are third party beneficiaries of these terms as related to your license of the app and that upon your acceptance of the terms and conditions of these terms app provider will have the right and will be deemed to have accepted the right to enforce these terms as related to your license of the app against you as a third party beneficiary thereof. you must also comply with all applicable third party terms of service when using the app. you agree to comply with all u s and foreign export laws and regulations to ensure that neither the app nor any technical data related thereto nor any direct product thereof is exported or re exported directly or indirectly in violation of or used for any purposes prohibited by such laws and regulations. by using the app you represent and warrant that i you are not located in a country that is subject to a u s government embargo or that has been designated by the u s government as a terrorist supporting country and ii you are not listed on any u s government list of prohibited or restricted parties.',\n",
+       "    'don t copy modify resell distribute or reverse engineer this app.',\n",
+       "    'license'],\n",
+       "   ['for purposes of these terms a content means the text software scripts graphics photos sounds music videos audiovisual combinations interactive features works of authorship of any kind and information or other materials that are posted generated provided or otherwise made available through the services and b user content means any content that account holders including you provide to be made available through the services. content includes without limitation user content. subject to your compliance with these terms niantic grants you a personal noncommercial nonexclusive nontransferable non sublicensable revocable license to download view display and use the content solely in connection with your permitted use of the services. content ownershipniantic does not claim any ownership rights in any user content and nothing in these terms will be deemed to restrict any rights that you may have to use and exploit your user content. subject to the foregoing niantic and its licensors including tpc and tpci exclusively own all right title and interest in and to the services and content including all associated intellectual property rights. you acknowledge that the services and content are protected by copyright trademark and other laws of the united states and foreign countries. you agree not to remove alter or obscure any copyright trademark service mark or other proprietary rights notices incorporated in or accompanying the services or content. rights granted by youby making any user content available through services you grant to niantic a nonexclusive perpetual irrevocable transferable sublicensable worldwide royalty free license to use copy modify create derivative works based upon publicly display publicly perform and distribute your user content in connection with operating and providing the services and content to you and to other account holders. you are solely responsible for all your user content. you represent and warrant that you own all your user content or you have all rights that are necessary to grant us the license rights in your user content under these terms. you also represent and warrant that neither your user content nor your use and provision of your user content to be made available through the services nor any use of your user content by niantic on or through the services will infringe misappropriate or violate a third party s intellectual property rights or rights of publicity or privacy or result in the violation of any applicable law or regulation. niantic may reject any submissions in which niantic believes in its sole discretion that the user content is inappropriate or violates the trainer guidelines or these terms. niantic further reserves the right to remove any user content from the services at any time and without notice and for any reason.',\n",
+       "    'we grant you full ownership of your user content. just don t hide our copyright trademarks.',\n",
+       "    'license to content'],\n",
+       "   ['the app permits account holders to capture and trade virtual items including but not limited to pok\\\\u00e9mon characters or creatures trading items during gameplay. unlike virtual money and virtual goods see below trading items are obtained at no additional charge during gameplay. trading items are a category of content and niantic grants you a limited nontransferable non sublicensable revocable license to use such trading items in conjunction with your personal noncommercial use of the services. you acknowledge that you do not acquire any ownership rights in or to trading items and that trading items do not have monetary value. trading items may be traded with other account holders for other trading items but trading items can never be sold transferred or exchanged for virtual money virtual goods real goods real money or real services or any other compensation or consideration from us or anyone else. you also agree that you will only obtain trading items from other account holders and through means provided by us and not from or through any third party platform exchange broker or other mechanism unless expressly authorized. we may cancel any trading items sold transferred or exchanged in violation of these terms. any such sale transfer or exchange or attempt to do so is prohibited and may result in the termination of your account. as set forth below all trading items and other content are provided as is without any warranty.',\n",
+       "    'trading s gonna be a thing. don t try to bring real money into it.',\n",
+       "    'trading items'],\n",
+       "   ['we may cancel suspend or terminate your account and your access to your trading items virtual money virtual goods the content or the services in our sole discretion and without prior notice including if a your account is inactive i e not used or logged into for one year b you fail to comply with these terms c we suspect fraud or misuse by you of trading items virtual money virtual goods or other content d we suspect any other unlawful activity associated with your account or e we are acting to protect the services our systems the app any of our users or the reputation of niantic tpc or tpci. we have no obligation or responsibility to and will not reimburse or refund you for any trading items virtual money or virtual goods lost due to such cancellation suspension or termination. you acknowledge that niantic is not required to provide a refund for any reason and that you will not receive money or other compensation for unused virtual money and virtual goods when your account is closed whether such closure was voluntary or involuntary. we have the right to offer modify eliminate and or terminate trading items virtual money virtual goods the content and or the services or any portion thereof at any time without notice or liability to you. if we discontinue the use of virtual money or virtual goods we will provide at least 60 days advance notice to you by posting a notice on the site or app or through other communications.',\n",
+       "    'if you haven t played for a year you mess up or we mess up we can delete all of your virtual goods. we don t have to give them back. we might even discontinue some virtual goods entirely but we ll give you 60 days advance notice if that happens.',\n",
+       "    'Cancellation Suspension and Termination'],\n",
+       "   ['the app permits the purchase of virtual currency virtual money and use of that virtual money to purchase virtual items or services that we expressly make available for use in the app virtual goods. the purchase of virtual money and virtual goods is limited to account holders who are either a 18 years of age or older or b under the age of 18 and have the consent of a parent to make the purchase. parents of children under the age of 18 can consult the ios or google play settings for their app to restrict in app purchases but should also monitor their children s accounts for unexpected activity including the purchase of virtual money or virtual goods. purchases of virtual money and virtual goodsvirtual money is a category of content so the purchase of virtual money grants you only a limited nontransferable non sublicensable revocable license to use such virtual money to access and purchase virtual goods in conjunction with your personal noncommercial use of the services. you acknowledge that you do not acquire any ownership rights in or to the virtual money virtual goods or other content any balance of virtual goods or virtual money does not reflect any stored value. you agree that virtual money and virtual goods have no monetary value and do not constitute actual currency or property of any type. virtual money may be redeemed only for virtual goods and can never be sold transferred or exchanged for real money real goods or real services from us or anyone else. you also agree that you will only obtain virtual money and or virtual goods from us and through means provided by us and not from any third party platform exchange broker or other mechanism unless expressly authorized. once you acquire a license to virtual money or virtual goods you may not trade or transfer the virtual money or virtual goods to another individual or account unless such functionality is provided to you by us by way of a feature or service whether inside the app or through some other method e g our website. we may cancel any virtual money or virtual goods sold transferred or exchanged in violation of these terms. any such sale transfer or exchange or attempt to do so is prohibited and may result in the termination of your account. during the term of your license to your virtual money you have the right to redeem your virtual money for selected virtual goods. if you are the parent and you are accepting these terms on behalf of your child you accept and acknowledge that your child has your consent to exercise this right independently. pricing and availability of virtual money and virtual goods are subject to change without notice. we reserve the right at any time to change and update our pricing and inventory of virtual money and virtual goods. as set forth below all virtual money virtual goods and other content is provided as is without any warranty. you agree that all sales by us to you of virtual money and virtual goods are final and that we will not permit exchanges or refunds for any unused virtual money or virtual goods once the transaction has been made. purchases by end users outside the u s virtual money and virtual goods may only be purchased and held by legal residents of countries where access to and use of the services are permitted. if you live in the european union you have certain rights to withdraw from online purchases. however please note that once you download virtual money from us your right of withdrawal ends. you agree that a purchase of virtual money involves immediate download of such content and b you lose your right of withdrawal once your purchase is complete. if you live in the european union we will provide you with a vat invoice when we are required to do so by law. you agree that these invoices may be electronic in format. we reserve the right to control regulate change or remove any virtual money or virtual goods without any liability to you.',\n",
+       "    'you can spend money on coins pokeballs. we ain t giving you that money back. want to buy gold online. too bad. oh and the eu gives people refund rights in some cases. not this one.',\n",
+       "    'be nice.'],\n",
+       "   ['you agree that you are responsible for your own conduct and user content while using the services and for any consequences thereof. please refer to our trainer guidelines https pokemongo nianticlabs com support guidelines en for information about the kinds of conduct and user content that are prohibited while using the services. by way of example and not as a limitation you agree that when using the services and content you will not defame abuse harass harm stalk threaten or otherwise violate the legal rights including the rights of privacy and publicity of others upload post email transmit or otherwise make available any unlawful inappropriate defamatory obscene pornographic vulgar offensive fraudulent false misleading or deceptive content or message promote or engage in discrimination bigotry racism hatred or harassment against any individual or group trespass or in any manner attempt to gain or gain access to any property or location where you do not have a right or permission to be violate or encourage any conduct that would violate any applicable law or regulation or would give rise to civil liability upload post or otherwise make available commercial messages or advertisements pyramid schemes or other disruptive notices impersonate or misrepresent your affiliation with another person or entity promote or provide instructional information about illegal or harmful activities or substances promote or engage in physical harm violence or injury against any group or individual transmit any viruses worms defects trojan horses or any items of a destructive nature submit fake falsified misleading or inappropriate data submissions edits or removals post upload publish submit or transmit any content that infringes misappropriates or violates a third party s patent copyright trademark trade secret moral rights or other intellectual property rights or rights of publicity or privacy use display mirror or frame the services or any individual element within the services niantic s name any niantic trademark logo or other proprietary information or the layout and design of any page or form contained on a page without niantic s express written consent access tamper with or use nonpublic areas of the services niantic s computer systems or the technical delivery systems of niantic s providers attempt to probe scan or test the vulnerability of any niantic system or network or breach any security or authentication measures avoid bypass remove deactivate impair descramble or otherwise circumvent any technological measure implemented by niantic or any of niantic s providers or any other third party including another user to protect the services or content attempt to access or search the services or content or download content from the services through the use of any technology or means other than those provided by niantic or other generally available third party web browsers including without limitation automation software bots spiders crawlers data mining tools or hacks tools agents engines or devices of any kind extract scrape index copy or mirror the services or content or portions thereof including but not limited to the pok\\\\u00e9stop database and other information about users or gameplay use any meta tags or other hidden text or metadata utilizing a niantic trademark logo url or product name without niantic s express written consent forge any tcp ip packet header or any part of the header information in any email or newsgroup posting or in any way use the services or content to send altered deceptive or false source identifying information attempt to decipher decompile disassemble or reverse engineer any of the software used to provide the services or content interfere with or attempt to interfere with the access of any user host or network including without limitation sending a virus overloading flooding spamming or mail bombing the services take any action that imposes or may impose an unreasonable or disproportionately large load on the services or niantic s infrastructure delete obscure or in any manner alter any attribution warning or link that appears in the services or the content use the services or content or any portion thereof for any commercial purpose or for the benefit of any third party or in a manner not permitted by these terms including but not limited to a gathering in app items or resources for sale outside the app b performing services in the app in exchange for payment outside the app or c sell resell rent or lease the app or your account collect or store any personally identifiable information from the services from other users of the services without their express permission violate any applicable law or regulation orencourage or enable any other individual to do any of the foregoing. although we re not obligated to monitor access to or use of the services or content or to review or edit any content we have the right to do so for the purpose of operating the services to ensure compliance with these terms and to comply with applicable law or other legal requirements. we reserve the right but are not obligated to remove or disable access to any content at any time and without notice including but not limited to if we at our sole discretion consider any content to be objectionable or in violation of these terms. we have the right to investigate violations of these terms or conduct that affects the services. we may also consult and cooperate with law enforcement authorities to prosecute users who violate the law.',\n",
+       "    'don t be a jerk. don t hack or cheat. we don t have to ban you but we can. we ll also cooperate with law enforcement.',\n",
+       "    'if you want to give us feedback, you can do so by clicking on the feedback button.'],\n",
+       "   ['by using our services you are agreeing to these terms our trainer guidelines and our privacy policy. if you are the parent or legal guardian of a child under the age of 13 the parent you are agreeing to these terms on behalf of yourself and your child ren who are authorized to use the services pursuant to these terms and in our privacy policy. if you don t agree to these terms our trainer guidelines and our privacy policy do not use the services.',\n",
+       "    'by playing this game you agree to these terms. if you re under 13 and playing your parent guardian agrees on your behalf.',\n",
+       "    'agree to these terms']]}]"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 54
   },
   {
    "cell_type": "markdown",
@@ -1550,9 +2657,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:48:59.549591Z",
+     "start_time": "2024-09-18T13:48:34.600658Z"
+    }
+   },
    "source": [
     "wos_client.data_sets.store_records(data_set_id=feedback_data_set_id, request_body=feedback_data,background_mode=False)\n",
     "time.sleep(5)\n",
@@ -1560,7 +2670,34 @@
     "# Adding time delay to enable drift\n",
     "time.sleep(10)\n",
     "print(\"Number of records in the feedback logging table: {}\".format(fb_records_count))"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "==========================================================================================\n",
+      "\n",
+      " Waiting for end of storing records with request id: 9ce03b43-0066-481d-912d-8c55a6ad1d45 \n",
+      "\n",
+      "==========================================================================================\n",
+      "\n",
+      "\n",
+      "\n",
+      "active\n",
+      "\n",
+      "---------------------------------------\n",
+      " Successfully finished storing records \n",
+      "---------------------------------------\n",
+      "\n",
+      "\n",
+      "Number of records in the feedback logging table: 10\n"
+     ]
+    }
+   ],
+   "execution_count": 55
   },
   {
    "cell_type": "markdown",
@@ -1572,12 +2709,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:49:03.374730Z",
+     "start_time": "2024-09-18T13:49:01.817870Z"
+    }
+   },
    "source": [
     "wos_client.monitor_instances.show(target_target_id = prod_subscription_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>Monitor instances</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>data_mart_id</th><th style='border: 1px solid #dddddd'>status</th><th style='border: 1px solid #dddddd'>target_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>created_at</th><th style='border: 1px solid #dddddd'>id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>58f9d73b-e4c6-43a8-8dc1-cbab5166ee0e</td><td style='border: 1px solid #dddddd'>active</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>2024-09-18 11:07:09.334000+00:00</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td></tr><tr><td style='border: 1px solid #dddddd'>58f9d73b-e4c6-43a8-8dc1-cbab5166ee0e</td><td style='border: 1px solid #dddddd'>active</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>2024-09-18 11:07:10.170000+00:00</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td></tr><tr><td style='border: 1px solid #dddddd'>58f9d73b-e4c6-43a8-8dc1-cbab5166ee0e</td><td style='border: 1px solid #dddddd'>active</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>2024-09-18 11:07:08.215000+00:00</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td></tr><tr><td style='border: 1px solid #dddddd'>58f9d73b-e4c6-43a8-8dc1-cbab5166ee0e</td><td style='border: 1px solid #dddddd'>active</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>2024-09-18 11:07:11.224000+00:00</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 56
   },
   {
    "cell_type": "markdown",
@@ -1590,9 +2753,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:49:24.111267Z",
+     "start_time": "2024-09-18T13:49:23.023594Z"
+    }
+   },
    "source": [
     "monitor_definition_id = \"mrm\"\n",
     "target_target_id = prod_subscription_id\n",
@@ -1603,7 +2769,20 @@
     "result_json = result._to_dict()\n",
     "mrm_monitor_id = result_json[\"monitor_instances\"][0][\"metadata\"][\"id\"]\n",
     "mrm_monitor_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'01d06467-3bc7-4809-9127-415b8d1522a8'"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 57
   },
   {
    "cell_type": "markdown",
@@ -1616,16 +2795,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:51:43.320794Z",
+     "start_time": "2024-09-18T13:49:26.554175Z"
+    }
+   },
    "source": [
     "response  = wos_client.monitor_instances.mrm.evaluate_risk(monitor_instance_id=mrm_monitor_id, \n",
     "                                                    body = body,\n",
     "                                                    space_id = space_id,\n",
     "                                                    evaluation_tests = [\"model_health\", \"drift_v2\", \"generative_ai_quality\"],\n",
     "                                                    background_mode = False)"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "=================================================================================\n",
+      "\n",
+      " Waiting for risk evaluation of MRM monitor 01d06467-3bc7-4809-9127-415b8d1522a8 \n",
+      "\n",
+      "=================================================================================\n",
+      "\n",
+      "\n",
+      "\n",
+      "running...............\n",
+      "finished\n",
+      "\n",
+      "---------------------------------------\n",
+      " Successfully finished evaluating risk \n",
+      "---------------------------------------\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 58
   },
   {
    "cell_type": "markdown",
@@ -1638,13 +2847,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:51:58.779784Z",
+     "start_time": "2024-09-18T13:51:55.738763Z"
+    }
+   },
    "source": [
     "response  = wos_client.monitor_instances.mrm.get_risk_evaluation(mrm_monitor_id, space_id = space_id)\n",
     "response.result.to_dict()"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'metadata': {'id': '6d0ca7f6-63ac-40e7-aa9c-0231add6e3ba',\n",
+       "  'created_at': '2024-09-18T13:49:32.880Z',\n",
+       "  'created_by': 'iam-ServiceId-b317a8da-d926-496e-b0ca-6bcc57f556ae'},\n",
+       " 'entity': {'triggered_by': 'user',\n",
+       "  'parameters': {'deployment_id': 'c44fac44-1f0d-4fa8-b541-ec4420bcddcc',\n",
+       "   'evaluation_start_time': '2024-09-18T13:49:30.510973Z',\n",
+       "   'facts': {'state': 'finished'},\n",
+       "   'measurement_id': '874914b5-419b-4865-a209-4e4861c70dd2',\n",
+       "   'prompt_template_asset_id': 'd47aaf8c-0c3c-4af6-b5c2-99b61df22f5c',\n",
+       "   'prompt_template_details': {'pta_resource_key': '9d4a937f3a051aa6c67086f040c77258518a725145f97f47d513ab6d5fb64045'},\n",
+       "   'space_id': 'bc592530-1cf0-4e56-9fab-70e0924f6907',\n",
+       "   'user_iam_id': 'IBMid-692000BLQ0',\n",
+       "   'publish_metrics': 'false',\n",
+       "   'evaluation_tests': []},\n",
+       "  'status': {'state': 'finished',\n",
+       "   'queued_at': '2024-09-18T13:49:32.848000Z',\n",
+       "   'started_at': '2024-09-18T13:49:33.570000Z',\n",
+       "   'updated_at': '2024-09-18T13:51:36.901000Z',\n",
+       "   'completed_at': '2024-09-18T13:51:32.141000Z',\n",
+       "   'message': 'Mrm evaluation complete.',\n",
+       "   'operators': []}}}"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 59
   },
   {
    "cell_type": "markdown",
@@ -1657,12 +2902,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:08.845635Z",
+     "start_time": "2024-09-18T13:51:59.685663Z"
+    }
+   },
    "source": [
     "wos_client.monitor_instances.show_metrics(monitor_instance_id=mrm_monitor_id, space_id=space_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>01d06467-3bc7-4809-9127-415b8d1522a8 Monitor Runs Metrics from: 2024-09-11 19:21:59.686855  till: 2024-09-18 19:21:59.686869</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>ts</th><th style='border: 1px solid #dddddd'>id</th><th style='border: 1px solid #dddddd'>measurement_id</th><th style='border: 1px solid #dddddd'>value</th><th style='border: 1px solid #dddddd'>lower_limit</th><th style='border: 1px solid #dddddd'>upper_limit</th><th style='border: 1px solid #dddddd'>tags</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>monitor_instance_id</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>target_id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:32.982000+00:00</td><td style='border: 1px solid #dddddd'>tests_passed</td><td style='border: 1px solid #dddddd'>874914b5-419b-4865-a209-4e4861c70dd2</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>6d0ca7f6-63ac-40e7-aa9c-0231add6e3ba</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:32.982000+00:00</td><td style='border: 1px solid #dddddd'>tests_run</td><td style='border: 1px solid #dddddd'>874914b5-419b-4865-a209-4e4861c70dd2</td><td style='border: 1px solid #dddddd'>2.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>6d0ca7f6-63ac-40e7-aa9c-0231add6e3ba</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:32.982000+00:00</td><td style='border: 1px solid #dddddd'>tests_skipped</td><td style='border: 1px solid #dddddd'>874914b5-419b-4865-a209-4e4861c70dd2</td><td style='border: 1px solid #dddddd'>2.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>6d0ca7f6-63ac-40e7-aa9c-0231add6e3ba</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:32.982000+00:00</td><td style='border: 1px solid #dddddd'>tests_failed</td><td style='border: 1px solid #dddddd'>874914b5-419b-4865-a209-4e4861c70dd2</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>6d0ca7f6-63ac-40e7-aa9c-0231add6e3ba</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:07:12.526000+00:00</td><td style='border: 1px solid #dddddd'>tests_passed</td><td style='border: 1px solid #dddddd'>f1e9217c-39bf-4875-9a22-16e2c609ee8a</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>17d002e4-d72c-4efd-a036-30af6462029e</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:07:12.526000+00:00</td><td style='border: 1px solid #dddddd'>tests_run</td><td style='border: 1px solid #dddddd'>f1e9217c-39bf-4875-9a22-16e2c609ee8a</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>17d002e4-d72c-4efd-a036-30af6462029e</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:07:12.526000+00:00</td><td style='border: 1px solid #dddddd'>tests_skipped</td><td style='border: 1px solid #dddddd'>f1e9217c-39bf-4875-9a22-16e2c609ee8a</td><td style='border: 1px solid #dddddd'>3.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>17d002e4-d72c-4efd-a036-30af6462029e</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:07:12.526000+00:00</td><td style='border: 1px solid #dddddd'>tests_failed</td><td style='border: 1px solid #dddddd'>f1e9217c-39bf-4875-9a22-16e2c609ee8a</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>17d002e4-d72c-4efd-a036-30af6462029e</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 12:07:12.711000+00:00</td><td style='border: 1px solid #dddddd'>tests_passed</td><td style='border: 1px solid #dddddd'>538523fa-e841-4ee1-a85e-1b5ae465a43e</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>2fdd8fd4-576f-43a9-af45-4242b83962aa</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 12:07:12.711000+00:00</td><td style='border: 1px solid #dddddd'>tests_run</td><td style='border: 1px solid #dddddd'>538523fa-e841-4ee1-a85e-1b5ae465a43e</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>mrm</td><td style='border: 1px solid #dddddd'>01d06467-3bc7-4809-9127-415b8d1522a8</td><td style='border: 1px solid #dddddd'>2fdd8fd4-576f-43a9-af45-4242b83962aa</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: First 10 records were displayed.\n"
+     ]
+    }
+   ],
+   "execution_count": 60
   },
   {
    "cell_type": "markdown",
@@ -1682,9 +2960,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:09.430021Z",
+     "start_time": "2024-09-18T13:52:08.849493Z"
+    }
+   },
    "source": [
     "monitor_definition_id = \"generative_ai_quality\"\n",
     "result = wos_client.monitor_instances.list(data_mart_id = data_mart_id,\n",
@@ -1694,7 +2975,20 @@
     "result_json = result._to_dict()\n",
     "genaiquality_monitor_id = result_json[\"monitor_instances\"][0][\"metadata\"][\"id\"]\n",
     "genaiquality_monitor_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'688c2bfa-8239-4cb3-b0b5-03457e91a899'"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 61
   },
   {
    "cell_type": "markdown",
@@ -1705,12 +2999,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:22.201271Z",
+     "start_time": "2024-09-18T13:52:15.797508Z"
+    }
+   },
    "source": [
     "wos_client.monitor_instances.show_metrics(monitor_instance_id=genaiquality_monitor_id, space_id=space_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>688c2bfa-8239-4cb3-b0b5-03457e91a899 Monitor Runs Metrics from: 2024-09-11 19:22:15.798523  till: 2024-09-18 19:22:15.798531</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>ts</th><th style='border: 1px solid #dddddd'>id</th><th style='border: 1px solid #dddddd'>measurement_id</th><th style='border: 1px solid #dddddd'>value</th><th style='border: 1px solid #dddddd'>lower_limit</th><th style='border: 1px solid #dddddd'>upper_limit</th><th style='border: 1px solid #dddddd'>tags</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>monitor_instance_id</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>target_id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>flesch_reading_ease</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>74.828</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>normalized_recall</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>0.0623</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>rouge2</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>0.048</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>records_processed</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>10.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>jaccard_similarity</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>0.0434</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>meteor</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>0.0518</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>rougelsum</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>0.1015</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>normalized_precision</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>0.3521</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>bleu</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>0.0009</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:50.074548+00:00</td><td style='border: 1px solid #dddddd'>normalized_f1</td><td style='border: 1px solid #dddddd'>6219d80b-c27c-49a1-a6b0-5d24630983bc</td><td style='border: 1px solid #dddddd'>0.1014</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['computed_on:feedback', 'field_type:subscription', 'aggregation_type:mean']</td><td style='border: 1px solid #dddddd'>generative_ai_quality</td><td style='border: 1px solid #dddddd'>688c2bfa-8239-4cb3-b0b5-03457e91a899</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: First 10 records were displayed.\n"
+     ]
+    }
+   ],
+   "execution_count": 62
   },
   {
    "cell_type": "markdown",
@@ -1728,9 +3055,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:28.843757Z",
+     "start_time": "2024-09-18T13:52:27.965787Z"
+    }
+   },
    "source": [
     "result = wos_client.data_sets.list(target_target_id = prod_subscription_id,\n",
     "                                target_target_type = \"subscription\",\n",
@@ -1738,7 +3068,20 @@
     "\n",
     "genaiq_dataset_id = result.data_sets[0].metadata.id\n",
     "genaiq_dataset_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'0b39acd8-227f-431c-86b8-6d9766458d6c'"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 63
   },
   {
    "cell_type": "markdown",
@@ -1749,12 +3092,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:31.506840Z",
+     "start_time": "2024-09-18T13:52:30.184202Z"
+    }
+   },
    "source": [
     "wos_client.data_sets.show_records(data_set_id = genaiq_dataset_id)"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>Data Set 0b39acd8-227f-431c-86b8-6d9766458d6c Records</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>flesch_reading_ease</th><th style='border: 1px solid #dddddd'>normalized_recall</th><th style='border: 1px solid #dddddd'>hap_input_score</th><th style='border: 1px solid #dddddd'>rouge2</th><th style='border: 1px solid #dddddd'>pii_entities</th><th style='border: 1px solid #dddddd'>scoring_id</th><th style='border: 1px solid #dddddd'>jaccard_similarity</th><th style='border: 1px solid #dddddd'>computed_on</th><th style='border: 1px solid #dddddd'>scoring_timestamp</th><th style='border: 1px solid #dddddd'>meteor</th><th style='border: 1px solid #dddddd'>rougelsum</th><th style='border: 1px solid #dddddd'>hap_score</th><th style='border: 1px solid #dddddd'>pii_input_entities</th><th style='border: 1px solid #dddddd'>pii</th><th style='border: 1px solid #dddddd'>normalized_precision</th><th style='border: 1px solid #dddddd'>hap_input_score_entities</th><th style='border: 1px solid #dddddd'>hap_score_positions</th><th style='border: 1px solid #dddddd'>bleu</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>normalized_f1</th><th style='border: 1px solid #dddddd'>pii_input_positions</th><th style='border: 1px solid #dddddd'>pii_positions</th><th style='border: 1px solid #dddddd'>rougel</th><th style='border: 1px solid #dddddd'>sari</th><th style='border: 1px solid #dddddd'>cosine_similarity</th><th style='border: 1px solid #dddddd'>hap_score_entities</th><th style='border: 1px solid #dddddd'>pii_input</th><th style='border: 1px solid #dddddd'>hap_input_score_positions</th><th style='border: 1px solid #dddddd'>rouge1</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>118.18</td><td style='border: 1px solid #dddddd'>0.17391304347826086</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.24</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>3c665f7d-52a5-4138-9806-0a220c2d9d52</td><td style='border: 1px solid #dddddd'>0.14285714285714285</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.467Z</td><td style='border: 1px solid #dddddd'>0.17330786026200873</td><td style='border: 1px solid #dddddd'>0.2963</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.005247518399181385</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.29629629629629634</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.2963</td><td style='border: 1px solid #dddddd'>55.38857182636525</td><td style='border: 1px solid #dddddd'>0.2554784079081934</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.2963</td></tr><tr><td style='border: 1px solid #dddddd'>-51.03</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>97017140-d46f-4fbc-ac82-6ce69ed29d8b</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.467Z</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>32.31787167470213</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td></tr><tr><td style='border: 1px solid #dddddd'>88.06</td><td style='border: 1px solid #dddddd'>0.11538461538461539</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>cf43f798-b535-484c-a1d9-a3c3ff72a501</td><td style='border: 1px solid #dddddd'>0.05714285714285714</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.467Z</td><td style='border: 1px solid #dddddd'>0.08389261744966442</td><td style='border: 1px solid #dddddd'>0.1429</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1875</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.14285714285714285</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1429</td><td style='border: 1px solid #dddddd'>35.84694939105468</td><td style='border: 1px solid #dddddd'>0.12750966661167926</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1429</td></tr><tr><td style='border: 1px solid #dddddd'>120.21</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>e3a095e7-e57f-4163-9ccd-157ff0483708</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.467Z</td><td style='border: 1px solid #dddddd'>0.013123359580052493</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>50.430470147243675</td><td style='border: 1px solid #dddddd'>0.25144644632566954</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td></tr><tr><td style='border: 1px solid #dddddd'>59.97</td><td style='border: 1px solid #dddddd'>0.02564102564102564</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>3e1c31b6-c280-4af4-80ba-e2709da02ebe</td><td style='border: 1px solid #dddddd'>0.02857142857142857</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.466Z</td><td style='border: 1px solid #dddddd'>0.013123359580052493</td><td style='border: 1px solid #dddddd'>0.0488</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.5</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.048780487804878044</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0488</td><td style='border: 1px solid #dddddd'>41.54530956428735</td><td style='border: 1px solid #dddddd'>0.03892030352151266</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0488</td></tr><tr><td style='border: 1px solid #dddddd'>77.91</td><td style='border: 1px solid #dddddd'>0.07142857142857142</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>5299e78b-9338-45e2-93e8-e5a22654d637</td><td style='border: 1px solid #dddddd'>0.0625</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.466Z</td><td style='border: 1px solid #dddddd'>0.03048780487804878</td><td style='border: 1px solid #dddddd'>0.125</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.5</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.125</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.125</td><td style='border: 1px solid #dddddd'>51.48144633916992</td><td style='border: 1px solid #dddddd'>0.09588552733473388</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.125</td></tr><tr><td style='border: 1px solid #dddddd'>36.62</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>625692d3-84e9-44fe-bdde-8fd8fa79693b</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.466Z</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>49.80506188720799</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td></tr><tr><td style='border: 1px solid #dddddd'>120.21</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>be585b4e-b0cd-4b75-a650-c0699ce9e75a</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.466Z</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>58.22730947160862</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td></tr><tr><td style='border: 1px solid #dddddd'>118.18</td><td style='border: 1px solid #dddddd'>0.17391304347826086</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.24</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>c3d9616a-3361-4af0-9cd2-9e4a09a6b671</td><td style='border: 1px solid #dddddd'>0.14285714285714285</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.466Z</td><td style='border: 1px solid #dddddd'>0.17330786026200873</td><td style='border: 1px solid #dddddd'>0.2963</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.005247518399181385</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.29629629629629634</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.2963</td><td style='border: 1px solid #dddddd'>55.38857182636525</td><td style='border: 1px solid #dddddd'>0.2554784079081934</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.2963</td></tr><tr><td style='border: 1px solid #dddddd'>59.97</td><td style='border: 1px solid #dddddd'>0.0625</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>cb76ff64-7b95-4fd9-b441-f7d7c2954d8b</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>feedback</td><td style='border: 1px solid #dddddd'>2024-09-18T13:48:36.466Z</td><td style='border: 1px solid #dddddd'>0.030303030303030304</td><td style='border: 1px solid #dddddd'>0.1053</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.3333333333333333</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.0</td><td style='border: 1px solid #dddddd'>bdf57dea-be5f-4863-93c7-d38db9a62112</td><td style='border: 1px solid #dddddd'>0.10526315789473684</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1053</td><td style='border: 1px solid #dddddd'>34.44215049903712</td><td style='border: 1px solid #dddddd'>0.07240380080811218</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>0.1053</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 64
   },
   {
    "cell_type": "markdown",
@@ -1765,9 +3134,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:34.876823Z",
+     "start_time": "2024-09-18T13:52:33.552450Z"
+    }
+   },
    "source": [
     "result = wos_client.data_sets.get_list_of_records(data_set_id = genaiq_dataset_id).result\n",
     "result[\"records\"]\n",
@@ -1778,7 +3150,9 @@
     "    x.append(each[\"metadata\"][\"id\"][-5:]) # Reading only last 5 characters to fit in the display\n",
     "    y_rougel.append(each[\"entity\"][\"values\"][\"rougel\"])\n",
     "    y_rougelsum.append(each[\"entity\"][\"values\"][\"rougelsum\"])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 65
   },
   {
    "cell_type": "markdown",
@@ -1789,9 +3163,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:36.417574Z",
+     "start_time": "2024-09-18T13:52:35.899682Z"
+    }
+   },
    "source": [
     "import matplotlib.pyplot as plt\n",
     "plt.scatter(x, y_rougel, marker='o')\n",
@@ -1803,7 +3180,20 @@
     "\n",
     "# Display the graph\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAHHCAYAAABXx+fLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABkv0lEQVR4nO3deXwN1/8/8NfNepOQSGQnkkiCWGONWEorldhKLY201o8utLQalFQJ1QpKi1IttdVSobS1NWhIF0LIInZBLCWLLQlBQvL+/eGX+bqScC+JkPt6Ph73wT1z5sz7zNx7552ZMzMqEREQERER6RGD8g6AiIiI6FljAkRERER6hwkQERER6R0mQERERKR3mAARERGR3mECRERERHqHCRARERHpHSZAREREpHeYABEREZHeYQJEROVq0qRJUKlU5R3GCy86OhoqlQrR0dGPrLds2TKoVCqcPXv2sW26ublh0KBBpRIf0fOGCRARERHpHSZARER6pH///rh9+zZcXV3LOxSicsUEiKgCysnJKe8QXngigtu3b5d3GIrSisfQ0BBqtZqnHUnvMQEiesEVjqE5evQo3nzzTVhbW6NNmzYAgHv37mHKlCnw8PCAqakp3Nzc8OmnnyI3N1ejDZVKhUmTJhVpu7gxIElJSWjXrh3MzMxQvXp1fPHFF1i6dGmx40r++OMPtG3bFhYWFqhcuTK6dOmCI0eO6NzH4cOHo1KlSrh161aRacHBwXB0dER+fj4A4MCBAwgICICtrS3MzMzg7u6O//3vf49dhpubG7p27Ypt27ahWbNmMDMzww8//AAAyMzMxMiRI+Hi4gJTU1N4enpi+vTpKCgo0GijoKAAc+bMQYMGDaBWq2FnZ4fAwEAcOHBAqaPtNnlUPP/99x969OgBCwsL2Nvb4+OPPy4yf0mKGwMkIvjiiy9QvXp1mJub4+WXX36i7UT0IjEq7wCIqHT06dMHXl5emDp1KkQEAPD2229j+fLl6N27N0aNGoV9+/YhPDwcx44dw6+//qrzMi5evIiXX34ZKpUKoaGhsLCwwI8//ghTU9MidVesWIGBAwciICAA06dPx61bt7BgwQK0adMGCQkJcHNz03q5QUFBmD9/PrZs2YI+ffoo5bdu3cKmTZswaNAgGBoaIiMjAx07doSdnR3GjRuHKlWq4OzZs9iwYYNWyzlx4gSCg4Px3nvv4Z133kHt2rVx69YttGvXDhcvXsR7772HGjVqYM+ePQgNDUVqaipmz56tzD9kyBAsW7YMnTp1wttvv4179+7hn3/+wd69e9GsWTMAum2T4uK5ffs2OnTogPPnz+PDDz+Es7MzVqxYgZ07d2q9Ph82ceJEfPHFF+jcuTM6d+6M+Ph4dOzYEXl5eU/cJtFzT4johRYWFiYAJDg4WKM8MTFRAMjbb7+tUT569GgBIDt37lTKAEhYWFiRtl1dXWXgwIHK+xEjRohKpZKEhASl7OrVq2JjYyMAJCUlRUREbty4IVWqVJF33nlHo720tDSxsrLSKC+M/1EKCgqkWrVq0qtXL43ytWvXCgD5+++/RUTk119/FQCyf//+R7ZXHFdXVwEgkZGRGuVTpkwRCwsLOXnypEb5uHHjxNDQUM6fPy8iIjt37hQA8uGHHxYbv4hu26SkeGbPni0AZO3atUpZTk6OeHp6CgDZtWvXI/u5dOlSjW2VkZEhJiYm0qVLFyVOEZFPP/1UAGhsf6KKhKfAiCqIoUOHarzfunUrACAkJESjfNSoUQCALVu26LyMyMhI+Pn5wcfHRymzsbHBW2+9pVFvx44dyMzMRHBwMK5cuaK8DA0N4evri127dum0XJVKhT59+mDr1q24efOmUh4REYFq1aopp/yqVKkCANi8eTPu3r2rc//c3d0REBCgUbZu3Tq0bdsW1tbWGn3x9/dHfn4+/v77bwDA+vXroVKpEBYWVmz8gO7bpLh4tm7dCicnJ/Tu3VspMzc3x7vvvqtzfwHgzz//RF5eHkaMGKExLmjkyJFP1B7Ri4IJEFEF4e7urvH+3LlzMDAwgKenp0a5o6MjqlSpgnPnzum8jHPnzhVpD0CRsuTkZADAK6+8Ajs7O43X9u3bkZGRofOyg4KCcPv2bWzcuBEAcPPmTWzduhV9+vRRdtzt2rVDr169MHnyZNja2qJ79+5YunSp1uNjHl6HhX2JjIws0g9/f38AUPpy+vRpODs7w8bGpsT2dd0mxcVTuA0eHsRcu3ZtrfpYXHsA4OXlpVFuZ2cHa2vrJ2qT6EXAMUBEFYSZmVmx5U9ztU/hwGJdFQ4OXrFiBRwdHYtMNzLS/aenZcuWcHNzw9q1a/Hmm29i06ZNuH37NoKCgpQ6KpUKv/zyC/bu3YtNmzZh27Zt+N///odZs2Zh7969qFSp0iOXUdw6LCgowKuvvopPPvmk2Hlq1aqlc1+03SYlbVMienpMgIgqKFdXVxQUFCA5ORne3t5KeXp6OjIzMzXuA2NtbY3MzEyN+fPy8pCamlqkzVOnThVZ1sNlHh4eAAB7e3vlSElpeOONNzBnzhxkZ2cjIiICbm5uaNmyZZF6LVu2RMuWLfHll19i9erVeOutt7BmzRq8/fbbOi/Tw8MDN2/efGw/PDw8sG3bNly7dq3Eo0C6bJOSuLq64vDhwxARjUTqxIkTWvaoaHvA/SNdNWvWVMovX76M69evP1GbRC8CngIjqqA6d+4MABpXKQHA119/DQDo0qWLUubh4aGMZSm0cOHCIkeAAgICEBMTg8TERKXs2rVrWLVqVZF6lpaWmDp1arFjcS5fvqxzf4D7p8Fyc3OxfPlyREZG4o033tCYfv36deUKuEKF45W0PQ32sDfeeAMxMTHYtm1bkWmZmZm4d+8eAKBXr14QEUyePLlIvcKYdNkmJencuTMuXbqEX375RSm7desWFi5cqF2HHuLv7w9jY2N8++23Guvu4RiJKhoeASKqoBo1aoSBAwdi4cKFyMzMRLt27RAbG4vly5ejR48eePnll5W6b7/9NoYOHYpevXrh1VdfxcGDB7Ft2zbY2tpqtPnJJ59g5cqVePXVVzFixAjlMvgaNWrg2rVryhEJS0tLLFiwAP3790eTJk3Qt29f2NnZ4fz589iyZQtat26NefPm6dynJk2awNPTE+PHj0dubq7G6S8AWL58Ob777ju8/vrr8PDwwI0bN7Bo0SJYWloqyYeuxowZg40bN6Jr164YNGgQmjZtipycHBw6dAi//PILzp49C1tbW7z88svo378/5s6di+TkZAQGBqKgoAD//PMPXn75ZQwfPlynbVKSd955B/PmzcOAAQMQFxcHJycnrFixAubm5k/UPzs7O4wePRrh4eHo2rUrOnfujISEBPzxxx9Ftj9RhVKu16AR0VMrvIz88uXLRabdvXtXJk+eLO7u7mJsbCwuLi4SGhoqd+7c0aiXn58vY8eOFVtbWzE3N5eAgAA5depUkcvgRUQSEhKkbdu2YmpqKtWrV5fw8HCZO3euAJC0tDSNurt27ZKAgACxsrIStVotHh4eMmjQIDlw4ECR+LU1fvx4ASCenp5FpsXHx0twcLDUqFFDTE1Nxd7eXrp27aqxvJK4urpKly5dip1248YNCQ0NFU9PTzExMRFbW1tp1aqVzJw5U/Ly8pR69+7dk6+++krq1KkjJiYmYmdnJ506dZK4uDiljrbb5FHxnDt3Tl577TUxNzcXW1tb+eijjyQyMvKJLoMXub/9J0+eLE5OTmJmZibt27eXw4cPF7v9iSoKlchDx4uJiHQ0cuRI/PDDD7h58yYMDQ3LOxwiosfiGCAi0snDz6O6evUqVqxYgTZt2jD5IaIXBscAEZFO/Pz80L59e3h7eyM9PR2LFy9GdnY2JkyYUN6hERFpjQkQEemkc+fO+OWXX7Bw4UKoVCo0adIEixcvxksvvVTeoRERaY1jgIiIiEjvcAwQERER6R0mQERERKR3OAaoGAUFBbh06RIqV678VM9RIiIiomdHRHDjxg04OzvDwODRx3iYABXj0qVLcHFxKe8wiIiI6AlcuHAB1atXf2QdJkDFqFy5MoD7K9DS0rKcoyEiIiJtZGdnw8XFRdmPPwoToGI8+DwjJkBEREQvFm2Gr3AQNBEREekdJkBERESkd5gAERERkd5hAkRERER6hwkQERER6Z3nIgGaP38+3NzcoFar4evri9jY2BLrbtiwAc2aNUOVKlVgYWEBHx8frFixQqOOiGDixIlwcnKCmZkZ/P39kZycXNbdICIiohdEuSdAERERCAkJQVhYGOLj49GoUSMEBAQgIyOj2Po2NjYYP348YmJikJSUhMGDB2Pw4MHYtm2bUmfGjBmYO3cuvv/+e+zbtw8WFhYICAjAnTt3nlW3iIiI6DlW7k+D9/X1RfPmzTFv3jwA9x9D4eLighEjRmDcuHFatdGkSRN06dIFU6ZMgYjA2dkZo0aNwujRowEAWVlZcHBwwLJly9C3b9/HtpednQ0rKytkZWXxPkBEREQvCF323+V6BCgvLw9xcXHw9/dXygwMDODv74+YmJjHzi8iiIqKwokTJ/DSSy8BAFJSUpCWlqbRppWVFXx9fbVqk4iIiCq+cr0T9JUrV5Cfnw8HBweNcgcHBxw/frzE+bKyslCtWjXk5ubC0NAQ3333HV599VUAQFpamtLGw20WTntYbm4ucnNzlffZ2dlP1J/HyS8QxKZcQ8aNO7CvrEYLdxsYGvBhq0RE9Gjcf5S+F/JRGJUrV0ZiYiJu3ryJqKgohISEoGbNmmjfvv0TtRceHo7JkyeXbpAPiTycismbjiI16//GITlZqRHWrS4C6zuV6bKJiOjFxf1H2SjXU2C2trYwNDREenq6Rnl6ejocHR1LnM/AwACenp7w8fHBqFGj0Lt3b4SHhwOAMp8ubYaGhiIrK0t5Xbhw4Wm6VUTk4VQMWxmv8eEFgLSsOxi2Mh6Rh1NLdXlERFQxcP9Rdso1ATIxMUHTpk0RFRWllBUUFCAqKgp+fn5at1NQUKCcwnJ3d4ejo6NGm9nZ2di3b1+JbZqamioPPi3tB6DmFwgmbzqK4kaaF5ZN3nQU+QXlOhadiIieM9x/lK1yPwUWEhKCgQMHolmzZmjRogVmz56NnJwcDB48GAAwYMAAVKtWTTnCEx4ejmbNmsHDwwO5ubnYunUrVqxYgQULFgC4/wTYkSNH4osvvoCXlxfc3d0xYcIEODs7o0ePHs+8f7Ep14pk7g8SAKlZdxCbcg1+HlWfXWBERPRc4/6jbJV7AhQUFITLly9j4sSJSEtLg4+PDyIjI5VBzOfPn4eBwf8dqMrJycH777+P//77D2ZmZqhTpw5WrlyJoKAgpc4nn3yCnJwcvPvuu8jMzESbNm0QGRkJtVr9zPuXcUO7ew9pW4+IiPQD9x9lq9zvA/Q8Ks37AMWcvorgRXsfW+/nd1oygyciIgX3H7p7Ye4DpA9auNvAyUqNki5WVOH+aP4W7jbPMiwiInrOcf9RtpgAlTFDAxXCutUFgCIf4sL3Yd3q8n4ORESkgfuPssUE6BkIrO+EBf2awNFKcwySo5UaC/o14X0ciIioWNx/lB2OASpGWT0LjHfyJCKiJ8H9h3Z02X+X+1Vg+sTQQMWBakREpDPuP0ofT4ERERGR3mECRERERHqHCRARERHpHSZAREREpHeYABEREZHeYQJEREREeocJEBEREekdJkBERESkd5gAERERkd5hAkRERER6hwkQERER6R0mQERERKR3mAARERGR3mECRERERHqHCRARERHpHSZAREREpHeYABEREZHeYQJEREREeocJEBEREekdJkBERESkd5gAERERkd5hAkRERER6hwkQERER6R0mQERERKR3mAARERGR3mECRERERHqHCRARERHpHSZAREREpHeYABEREZHeYQJEREREeocJEBEREekdJkBERESkd5gAERERkd5hAkRERER6hwkQERER6R0mQERERKR3mAARERGR3mECRERERHqHCRARERHpHSZAREREpHeYABEREZHeeS4SoPnz58PNzQ1qtRq+vr6IjY0tse6iRYvQtm1bWFtbw9raGv7+/kXqDxo0CCqVSuMVGBhY1t0gIiKiF0S5J0AREREICQlBWFgY4uPj0ahRIwQEBCAjI6PY+tHR0QgODsauXbsQExMDFxcXdOzYERcvXtSoFxgYiNTUVOX1888/P4vuEBER0QtAJSJSngH4+vqiefPmmDdvHgCgoKAALi4uGDFiBMaNG/fY+fPz82FtbY158+ZhwIABAO4fAcrMzMRvv/32RDFlZ2fDysoKWVlZsLS0fKI2iIiI6NnSZf9drkeA8vLyEBcXB39/f6XMwMAA/v7+iImJ0aqNW7du4e7du7CxsdEoj46Ohr29PWrXro1hw4bh6tWrJbaRm5uL7OxsjRcRERFVXOWaAF25cgX5+flwcHDQKHdwcEBaWppWbYwdOxbOzs4aSVRgYCB++uknREVFYfr06fjrr7/QqVMn5OfnF9tGeHg4rKyslJeLi8uTd4qIiIiee0blHcDTmDZtGtasWYPo6Gio1WqlvG/fvsr/GzRogIYNG8LDwwPR0dHo0KFDkXZCQ0MREhKivM/OzmYSREREVIGV6xEgW1tbGBoaIj09XaM8PT0djo6Oj5x35syZmDZtGrZv346GDRs+sm7NmjVha2uLU6dOFTvd1NQUlpaWGi8iIiKquMo1ATIxMUHTpk0RFRWllBUUFCAqKgp+fn4lzjdjxgxMmTIFkZGRaNas2WOX899//+Hq1atwcnIqlbiJiIjoxVbul8GHhIRg0aJFWL58OY4dO4Zhw4YhJycHgwcPBgAMGDAAoaGhSv3p06djwoQJWLJkCdzc3JCWloa0tDTcvHkTAHDz5k2MGTMGe/fuxdmzZxEVFYXu3bvD09MTAQEB5dJHIiIier6U+xigoKAgXL58GRMnTkRaWhp8fHwQGRmpDIw+f/48DAz+L09bsGAB8vLy0Lt3b412wsLCMGnSJBgaGiIpKQnLly9HZmYmnJ2d0bFjR0yZMgWmpqbPtG9ERET0fCr3+wA9j3gfICIiohfPC3MfICIiIqLywASIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPTOc5EAzZ8/H25ublCr1fD19UVsbGyJdRctWoS2bdvC2toa1tbW8Pf3L1JfRDBx4kQ4OTnBzMwM/v7+SE5OLutuEBER0Qui3BOgiIgIhISEICwsDPHx8WjUqBECAgKQkZFRbP3o6GgEBwdj165diImJgYuLCzp27IiLFy8qdWbMmIG5c+fi+++/x759+2BhYYGAgADcuXPnWXWLiIiInmMqEZHyDMDX1xfNmzfHvHnzAAAFBQVwcXHBiBEjMG7cuMfOn5+fD2tra8ybNw8DBgyAiMDZ2RmjRo3C6NGjAQBZWVlwcHDAsmXL0Ldv38e2mZ2dDSsrK2RlZcHS0vLpOkhERETPhC7773I9ApSXl4e4uDj4+/srZQYGBvD390dMTIxWbdy6dQt3796FjY0NACAlJQVpaWkabVpZWcHX17fENnNzc5Gdna3xIiIiooqrXBOgK1euID8/Hw4ODhrlDg4OSEtL06qNsWPHwtnZWUl4CufTpc3w8HBYWVkpLxcXF127QkRERC+Qch8D9DSmTZuGNWvW4Ndff4VarX7idkJDQ5GVlaW8Lly4UIpREhER0fPGqDwXbmtrC0NDQ6Snp2uUp6enw9HR8ZHzzpw5E9OmTcOff/6Jhg0bKuWF86Wnp8PJyUmjTR8fn2LbMjU1hamp6RP2goiIiF405XoEyMTEBE2bNkVUVJRSVlBQgKioKPj5+ZU434wZMzBlyhRERkaiWbNmGtPc3d3h6Oio0WZ2djb27dv3yDaJiIhIf5TrESAACAkJwcCBA9GsWTO0aNECs2fPRk5ODgYPHgwAGDBgAKpVq4bw8HAAwPTp0zFx4kSsXr0abm5uyrieSpUqoVKlSlCpVBg5ciS++OILeHl5wd3dHRMmTICzszN69OhRXt0kIiKi50ipJUDHjx/Ha6+9hpMnT+o0X1BQEC5fvoyJEyciLS0NPj4+iIyMVAYxnz9/HgYG/3egasGCBcjLy0Pv3r012gkLC8OkSZMAAJ988glycnLw7rvvIjMzE23atEFkZORTjRMiIiKiiqPU7gN08OBBNGnSBPn5+aXRXLnifYCIiIhePC/MfYCIiIiIygMTICIiItI7TICIiIhI72g9CNra2hoqlarE6ffu3SuVgIiIiIjKmtYJ0DfffPPIBIiIiIjoRaF1AjRo0KAyDIOIiIjo2dF6DFBsbOwjL3HPzc3F2rVrSyUoIiIiorKkdQLk5+eHq1evKu8tLS1x5swZ5X1mZiaCg4NLNzoiIiKiMqB1AvTw/RKLu39iKd1TkYiIiKhMlepl8BwkTURERC8C3geIiIiI9I5OD0M9evSo8vR1EcHx48dx8+ZNAMCVK1dKPzoiIiKiMqD1w1ANDAygUqmKHedTWK5SqfgwVCIiIioXuuy/tT4ClJKS8tSBERERET0PtE6AXF1dyzIOIiIiomdGpzFA2dnZyiGlrVu3ajz/y9DQEF26dCnd6IiIiIjKgNYJ0ObNmzFhwgQkJCQAAIKCgpCTk6NMV6lUiIiIQO/evUs/SiIiIqJSpPVl8AsXLsSIESM0yk6dOoWCggIUFBQgPDwcS5YsKfUAiYiIiEqb1gnQoUOH0Lp16xKnd+rUCQcOHCiVoIiIiIjKktYJUGpqKkxNTZX3u3btgouLi/K+UqVKyMrKKt3oiIiIiMqA1gmQjY0NTp06pbxv1qwZjI2NlffJycmwsbEp3eiIiIiIyoDWCdBLL72EuXPnljh97ty5eOmll0olKCIiIqKypHUCNHbsWGzfvh19+vTB/v37kZWVhaysLMTGxqJXr174888/MXbs2LKMlYiIiKhUaH0ZfOPGjREREYG3334bGzZs0JhmbW2NNWvWoEmTJqUeIBEREVFp0/pZYIVu3bqFbdu2ITk5GQDg5eWFjh07wsLCokwCLA98FhgREdGLp0yeBVbI3Nwcr7/++hMHR0RERFTetE6AQkJCii23srJCrVq10LNnT43L5ImIiIieV1onQIWPwHhYZmYmTp06hQkTJmDnzp2oUaNGqQVHREREVBZ0HgNUnOzsbLz11luoXLkyVq9eXRpxlSuOASIiInrx6LL/1voy+EextLTEhAkTsHv37tJojoiIiKhMlUoCBAC2tra4du1aaTVHREREVGZKLQHau3cvPDw8Sqs5IiIiojKj9SDopKSkYsuzsrIQFxeHqVOnIiwsrNQCIyIiIiorWidAPj4+UKlUKG7MtK2tLUJCQvD++++XanBEREREZUHrBCglJaXYcktLS1hbW5daQERERERlTesEyNXVtSzjICIiInpmdB4EvW7dOvTs2RP169dH/fr10bNnT/zyyy9lERsRERFRmdA6ASooKEBQUBCCgoJw9OhReHp6wtPTE0eOHEFQUBD69u1b7PggIiIioueN1qfA5syZgz///BMbN25E165dNaZt3LgRgwcPxpw5czBy5MjSjpGIiIioVGl9BGjp0qX46quviiQ/APDaa69hxowZWLJkSakGR0RERFQWtE6AkpOT4e/vX+J0f39/JCcnl0pQRERERGVJ6wTIzMwMmZmZJU7Pzs6GWq0ujZiIiIiIypTWCZCfnx8WLFhQ4vT58+fDz8+vVIIiIiIiKktaD4IeP3482rdvj6tXr2L06NGoU6cORATHjh3DrFmz8Pvvv2PXrl1lGSsRERFRqdA6AWrVqhUiIiLw7rvvYv369RrTrK2t8fPPP6N169alHiARERFRaVOJjjfvuXXrFrZt26YMeK5VqxY6duwIc3PzMgmwPGRnZ8PKygpZWVmwtLQs73CIiIhIC7rsv3W+E7S5uTlef/11fPLJJ/jkk0/Qo0cPJfm5ePGizsHOnz8fbm5uUKvV8PX1RWxsbIl1jxw5gl69esHNzQ0qlQqzZ88uUmfSpElQqVQarzp16ugcFxEREVVcOidAxUlLS8OIESPg5eWl03wREREICQlBWFgY4uPj0ahRIwQEBCAjI6PY+rdu3ULNmjUxbdo0ODo6lthuvXr1kJqaqrz+/fdfneIiIiKiik3rBOj69esIDg6Gra0tnJ2dMXfuXBQUFGDixImoWbMm9u/fj6VLl+q08K+//hrvvPMOBg8ejLp16+L777+Hubl5iTdUbN68Ob766iv07dsXpqamJbZrZGQER0dH5WVra6tTXERERFSxaT0Iety4cdizZw8GDRqEbdu24eOPP0ZkZCQMDAywc+dOtGzZUqcF5+XlIS4uDqGhoUqZgYEB/P39ERMTo1NbD0tOToazszPUajX8/PwQHh6OGjVqlFg/NzcXubm5yvvs7OynWj4RERE937Q+AvTHH39g6dKlmDlzJjZt2gQRgY+PDzZv3qxz8gMAV65cQX5+PhwcHDTKHRwckJaWpnN7hXx9fbFs2TJERkZiwYIFSElJQdu2bXHjxo0S5wkPD4eVlZXycnFxeeLlExER0fNP6wTo0qVL8Pb2BgBl0HK/fv3KLLAn1alTJ/Tp0wcNGzZEQEAAtm7diszMTKxdu7bEeUJDQ5GVlaW8Lly48AwjJiIiomdN61NgIgIjo/+rbmhoCDMzsydesK2tLQwNDZGenq5Rnp6e/sgBzrqqUqUKatWqhVOnTpVYx9TU9JFjioiIiKhi0SkB6tChg5IE3b59G926dYOJiYlGvfj4eK3aMzExQdOmTREVFYUePXoAAAoKChAVFYXhw4drG9Zj3bx5E6dPn0b//v1LrU2qGPILBLEp15Bx4w7sK6vRwt0Ghgaq8g6LiIieAa0ToLCwMI333bt3f+qFh4SEYODAgWjWrBlatGiB2bNnIycnB4MHDwYADBgwANWqVUN4eDiA+wOnjx49qvz/4sWLSExMRKVKleDp6QkAGD16NLp16wZXV1dcunQJYWFhMDQ0RHBw8FPHSxVH5OFUTN50FKlZd5QyJys1wrrVRWB9p3KMjIiIngWd7wRd2ubNm4evvvoKaWlp8PHxwdy5c+Hr6wsAaN++Pdzc3LBs2TIAwNmzZ+Hu7l6kjXbt2iE6OhoA0LdvX/z999+4evUq7Ozs0KZNG3z55Zfw8PDQOibeCbpiizycimEr4/HwB7/w2M+Cfk2YBBERvYB02X+XewL0PGICVHHlFwjaTN+pceTnQSoAjlZq/Dv2FZ4OIyJ6wZTpozCIXmSxKddKTH4AQACkZt1BbMq1ZxcUERE9c0yASK9k3Cg5+XmSekRE9GJiAkR6xb6yulTrERHRi+mpEqD//vsPBQUFpRULUZlr4W4DJys1Shrdo8L9q8FauNs8y7CIiOgZe6oEqG7dujh79mwphUJU9gwNVAjrVhcAiiRBhe/DutXlAGgiogruqRIgXkBGL6LA+k5Y0K8JHK00T3M5Wql5CTwRkZ7Q+kaIRBVJYH0nvFrXkXeCJiLSU0+VAH366aewseFYCXoxGRqo4OdRtbzDICKicsAbIRaDN0IkIiJ68fBGiERERESPwASIiIiI9A4TICIiItI7TICIiIhI7+icAEVGRuLff/9V3s+fPx8+Pj548803cf369VINjoiIiKgs6JwAjRkzBtnZ2QCAQ4cOYdSoUejcuTNSUlIQEhJS6gESERERlTad7wOUkpKCunXvP0pg/fr16Nq1K6ZOnYr4+Hh07ty51AMkIiIiKm06J0AmJia4desWAODPP//EgAEDAAA2NjbKkSEiIn2VXyC8wzjRC0DnBKhNmzYICQlB69atERsbi4iICADAyZMnUb169VIPkIjoRRF5OBWTNx1FatYdpczJSo2wbnX5jDmi54zOY4DmzZsHIyMj/PLLL1iwYAGqVasGAPjjjz8QGBhY6gESEb0IIg+nYtjKeI3kBwDSsu5g2Mp4RB5OLafIiKg4fBRGMfgoDCLSRX6BoM30nUWSn0IqAI5Wavw79hWeDiMqQ7rsv7U6BZadna009LhxPkwYiEjfxKZcKzH5AQABkJp1B7Ep1/gAXqLnhFYJkLW1NVJTU2Fvb48qVapApSr6F4yIQKVSIT8/v9SDJCJ6nmXcKDn5eZJ6RFT2tEqAdu7cCRsbG+X/xSVARET6yr6yulTrEVHZ0yoBateunfL/9u3bl1UsREQvpBbuNnCyUiMt6w6KG1RZOAaohbvNsw6NiEqg81VgkyZNQkFBQZHyrKwsBAcHl0pQREQvEkMDFcK63b9B7MPHxwvfh3WrywHQRM8RnROgxYsXo02bNjhz5oxSFh0djQYNGuD06dOlGhwR0YsisL4TFvRrAkcrzdNcjlZqLOjXhPcBInrO6HwjxKSkJLz33nvw8fHBrFmzcPLkScyZMwdjxozB5MmTyyJGIqIXQmB9J7xa15F3giZ6ATzxfYA+/fRTTJs2DUZGRvjjjz/QoUOH0o6t3PA+QERERC8eXfbfOp8CA4Bvv/0Wc+bMQXBwMGrWrIkPP/wQBw8efKJgiYiIiJ41nROgwMBATJ48GcuXL8eqVauQkJCAl156CS1btsSMGTPKIkYiIiKiUqVzApSfn4+kpCT07t0bAGBmZoYFCxbgl19+wTfffFPqARIRERGVtlJ9FtiVK1dga2tbWs2VG44BIiIievGU+RigklSE5IeIiIgqPp0vg8/Pz8c333yDtWvX4vz588jLy9OYfu3atVILjoiIiKgs6HwEaPLkyfj6668RFBSErKwshISEoGfPnjAwMMCkSZPKIEQiIiKi0qVzArRq1SosWrQIo0aNgpGREYKDg/Hjjz9i4sSJ2Lt3b1nESERERFSqdE6A0tLS0KBBAwBApUqVkJWVBQDo2rUrtmzZUrrREREREZUBnROg6tWrIzU1FQDg4eGB7du3AwD2798PU1PT0o2OiIiIqAzonAC9/vrriIqKAgCMGDECEyZMgJeXFwYMGID//e9/pR4gERERUWl76vsAxcTEICYmBl5eXujWrVtpxVWueB8gIiKi0pdfIGX6sGBd9t86Xwb/MD8/P/j5+T1tM0RERFSBRR5OxeRNR5GadUcpc7JSI6xbXQTWd3rm8TzVjRAtLS1x5syZ0oqFiIiIKqDIw6kYtjJeI/kBgLSsOxi2Mh6Rh1OfeUxaJ0CXLl0qUlaKT9EgIiKiCii/QDB501EUlzEUlk3edBT5Bc82p9A6AapXrx5Wr15dlrEQERFRBRObcq3IkZ8HCYDUrDuITXm2T5LQOgH68ssv8d5776FPnz7K4y769evHQcJERERUoowbJSc/T1KvtGidAL3//vtISkrC1atXUbduXWzatAkLFix46gegzp8/H25ublCr1fD19UVsbGyJdY8cOYJevXrBzc0NKpUKs2fPfuo2iYiIqOzYV1aXar3SotMgaHd3d+zcuROfffYZevbsiYYNG6JJkyYaL11EREQgJCQEYWFhiI+PR6NGjRAQEICMjIxi69+6dQs1a9bEtGnT4OjoWCptEhERUdlp4W4DJys1SrrYXYX7V4O1cLd5lmHpfh+gc+fOYfDgwTh8+DDee+89GBlpXkkfFhamdVu+vr5o3rw55s2bBwAoKCiAi4sLRowYgXHjxj1yXjc3N4wcORIjR44stTYL8T5AREREpafwKjAAGoOhC5OiBf2alMql8GV2H6DCh6D6+/vjyJEjsLOze+Ig8/LyEBcXh9DQUKXMwMAA/v7+iImJeW7aJCIioqcTWN8JC/o1KXIfIMdyvA+Q1glQYGAgYmNjMW/ePAwYMOCpF3zlyhXk5+fDwcFBo9zBwQHHjx9/pm3m5uYiNzdXeZ+dnf1EyyciIqLiBdZ3wqt1Hcv0TtC60DoBys/PR1JSEqpXr16W8ZSL8PBwTJ48ubzDICIiqtAMDVTw86ha3mEA0GEQ9I4dO0o1+bG1tYWhoSHS09M1ytPT00sc4FxWbYaGhiIrK0t5Xbhw4YmWT0RERC+Gp3oUxtMwMTFB06ZNlSfLA/cHLEdFRT3xs8WetE1TU1NYWlpqvIiIiKjieuqHoT6NkJAQDBw4EM2aNUOLFi0we/Zs5OTkYPDgwQCAAQMGoFq1aggPDwdwf5Dz0aNHlf9fvHgRiYmJqFSpEjw9PbVqk4iIiKhcE6CgoCBcvnwZEydORFpaGnx8fBAZGakMYj5//jwMDP7vINWlS5fQuHFj5f3MmTMxc+ZMtGvXDtHR0Vq1SURERKTzfYD0Ae8DRERE9OLRZf9dbmOAiIiIiMoLEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jvPRQI0f/58uLm5Qa1Ww9fXF7GxsY+sv27dOtSpUwdqtRoNGjTA1q1bNaYPGjQIKpVK4xUYGFiWXSAiIqIXSLknQBEREQgJCUFYWBji4+PRqFEjBAQEICMjo9j6e/bsQXBwMIYMGYKEhAT06NEDPXr0wOHDhzXqBQYGIjU1VXn9/PPPz6I7RPSE8gsEMaev4vfEi4g5fRX5BVLeIRFRBaYSkXL9lfH19UXz5s0xb948AEBBQQFcXFwwYsQIjBs3rkj9oKAg5OTkYPPmzUpZy5Yt4ePjg++//x7A/SNAmZmZ+O23354opuzsbFhZWSErKwuWlpZP1AYRaS/ycCombzqK1Kw7SpmTlRph3eoisL5TOUZGRC8SXfbf5XoEKC8vD3FxcfD391fKDAwM4O/vj5iYmGLniYmJ0agPAAEBAUXqR0dHw97eHrVr18awYcNw9erVEuPIzc1Fdna2xouIno3Iw6kYtjJeI/kBgLSsOxi2Mh6Rh1PLKTIiqsjKNQG6cuUK8vPz4eDgoFHu4OCAtLS0YudJS0t7bP3AwED89NNPiIqKwvTp0/HXX3+hU6dOyM/PL7bN8PBwWFlZKS8XF5en7BkRaSO/QDB501EUdxi6sGzypqM8HUZEpc6ovAMoC3379lX+36BBAzRs2BAeHh6Ijo5Ghw4ditQPDQ1FSEiI8j47O5tJENEzEJtyrciRnwcJgNSsO4hNuQY/j6rPLjAiqvDK9QiQra0tDA0NkZ6erlGenp4OR0fHYudxdHTUqT4A1KxZE7a2tjh16lSx001NTWFpaanxIqKyl3Gj5OTnSeoREWmrXBMgExMTNG3aFFFRUUpZQUEBoqKi4OfnV+w8fn5+GvUBYMeOHSXWB4D//vsPV69ehZMTB1MSPU/sK6tLtR4RkbbK/TL4kJAQLFq0CMuXL8exY8cwbNgw5OTkYPDgwQCAAQMGIDQ0VKn/0UcfITIyErNmzcLx48cxadIkHDhwAMOHDwcA3Lx5E2PGjMHevXtx9uxZREVFoXv37vD09ERAQEC59JGIitfC3QZOVmqoSpiuwv2rwVq42zzLsIhID5T7GKCgoCBcvnwZEydORFpaGnx8fBAZGakMdD5//jwMDP4vT2vVqhVWr16Nzz77DJ9++im8vLzw22+/oX79+gAAQ0NDJCUlYfny5cjMzISzszM6duyIKVOmwNTUtFz6SETFMzRQIaxbXQxbGQ8VoDEYujApCutWF4YGJaVIRERPptzvA/Q84n2AiJ4t3geIiEqDLvvvcj8CREQUWN8Jr9Z1RGzKNWTcuAP7yvdPe/HIDxGVFSZARPRcMDRQ8VJ3Inpmyn0QNBEREdGzxgSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiIiIiPQOEyAiIiLSO0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtG5R0AvXjyCwSxKdeQceMO7Cur0cLdBoYGqvIOS29xe1BZqCifq4rSDyp9z0UCNH/+fHz11VdIS0tDo0aN8O2336JFixYl1l+3bh0mTJiAs2fPwsvLC9OnT0fnzp2V6SKCsLAwLFq0CJmZmWjdujUWLFgALy+vZ9GdCi3ycCombzqK1Kw7SpmTlRph3eoisL5TOUamn7g9qCxUlM9VRekHlY1yPwUWERGBkJAQhIWFIT4+Ho0aNUJAQAAyMjKKrb9nzx4EBwdjyJAhSEhIQI8ePdCjRw8cPnxYqTNjxgzMnTsX33//Pfbt2wcLCwsEBATgzp07xbZJ2ok8nIphK+M1fkwAIC3rDoatjEfk4dRyikw/cXtQWagon6uK0g8qOyoRkfIMwNfXF82bN8e8efMAAAUFBXBxccGIESMwbty4IvWDgoKQk5ODzZs3K2UtW7aEj48Pvv/+e4gInJ2dMWrUKIwePRoAkJWVBQcHByxbtgx9+/Z9bEzZ2dmwsrJCVlYWLC0tS6mnL7b8AkGb6TuL/JgUUgFwtFLj37Gv8PDyM8DtQWWhonyuKko/SHe67L/L9QhQXl4e4uLi4O/vr5QZGBjA398fMTExxc4TExOjUR8AAgIClPopKSlIS0vTqGNlZQVfX98S28zNzUV2drbGizTFplwr8ccEAARAatYdxKZce3ZB6TFuDyoLFeVzVVH6QWWrXBOgK1euID8/Hw4ODhrlDg4OSEtLK3aetLS0R9Yv/FeXNsPDw2FlZaW8XFxcnqg/FVnGDe1OH2pbj54OtweVhYryuaoo/aCyVe5jgJ4HoaGhyMrKUl4XLlwo75CeO/aV1aVaj54OtweVhYryuaoo/aCyVa4JkK2tLQwNDZGenq5Rnp6eDkdHx2LncXR0fGT9wn91adPU1BSWlpYaL9LUwt0GTlZqlHS2XIX7V1e0cLd5lmHpLW4PKgsV5XNVUfpBZatcEyATExM0bdoUUVFRSllBQQGioqLg5+dX7Dx+fn4a9QFgx44dSn13d3c4Ojpq1MnOzsa+fftKbJMez9BAhbBudQGgyI9K4fuwbnU5oPAZ4fagslBRPlcVpR9Utsr9FFhISAgWLVqE5cuX49ixYxg2bBhycnIwePBgAMCAAQMQGhqq1P/oo48QGRmJWbNm4fjx45g0aRIOHDiA4cOHAwBUKhVGjhyJL774Ahs3bsShQ4cwYMAAODs7o0ePHuXRxQojsL4TFvRrAkcrzcPGjlZqLOjXhPfVeMa4PagsVJTPVUXpB5Wdcr8MHgDmzZun3AjRx8cHc+fOha+vLwCgffv2cHNzw7Jly5T669atw2effabcCHHGjBnF3ghx4cKFyMzMRJs2bfDdd9+hVq1aWsXDy+AfjXdWfb5we1BZqCifq4rSD9KOLvvv5yIBet4wASIiInrxvDD3ASIiIiIqD0yAiIiISO8wASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtG5R3A86jw5tjZ2dnlHAkRERFpq3C/rc1DLpgAFePGjRsAABcXl3KOhIiIiHR148YNWFlZPbIOnwVWjIKCAly6dAmVK1eGSlW6D83Lzs6Gi4sLLly48EI/Z4z9eL6wH88X9uP5wn48X8qyHyKCGzduwNnZGQYGjx7lwyNAxTAwMED16tXLdBmWlpYv9Ae4EPvxfGE/ni/sx/OF/Xi+lFU/HnfkpxAHQRMREZHeYQJEREREeocJ0DNmamqKsLAwmJqalncoT4X9eL6wH88X9uP5wn48X56XfnAQNBEREekdHgEiIiIivcMEiIiIiPQOEyAiIiLSO0yAnkD79u0xcuTIp2pDpVLht99+K5V4ytPZs2ehUqmQmJio9TzLli1DlSpVyiwmqnhK4ztXFirK97gs8HuuHTc3N8yePbu8w3jmoqOjoVKpkJmZqfU8kyZNgo+PT6nFwAToKaWnp2PQoEFwdnaGubk5AgMDkZycrHM7bm5uUKlUGq9p06Yp06Ojo9G9e3c4OTnBwsICPj4+WLVqldbth4eHo3nz5qhcuTLs7e3Ro0cPnDhxQqPO6dOn8frrr8POzg6WlpZ44403kJ6ernNf9u/fjw4dOqBKlSqwtrZGQEAADh48qHM7T9qPxylM2h5+7d27V6PeunXrUKdOHajVajRo0ABbt27VmL5hwwZ07NgRVatW1TkJzM/Px4QJE+Du7g4zMzN4eHhgypQpGs+vmTRpEurUqQMLCwtYW1vD398f+/btU6YX/oAU99q/f79SLykpCW3btoVarYaLiwtmzJhRJJ7Zs2ejdu3aMDMzg4uLCz7++GPcuXNH6/7Mnz8fbm5uUKvV8PX1RWxsLADg2rVrGDFihNJ2jRo18OGHHyIrK0vrtsvDtGnToFKpnijp2rJlC3x9fWFmZgZra2v06NFDmXb16lUEBgbC2dkZpqamcHFxwfDhwzWeOzho0KBit2m9evW0Wv6NGzcwcuRIuLq6wszMDK1atdL4PADAsWPH8Nprr8HKygoWFhZo3rw5zp8/r0zX5rfgtddeQ40aNaBWq+Hk5IT+/fvj0qVLOq+vp+nHo0yaNKnY9WhhYaHUWbZsWZHparW61PoAABcvXkS/fv1QtWpVmJmZoUGDBjhw4IDO7cTExOCVV16BhYUFLC0t8dJLL+H27dsAtPstuHPnDgYNGoQGDRrAyMhI43P5OMWtyzp16hSpJyLo1KnTE/9hsG3bNrRs2RKVK1eGnZ0devXqhbNnz+rcjraYAD0FEUGPHj1w5swZ/P7770hISICrqyv8/f2Rk5Ojc3uff/45UlNTldeIESOUaXv27EHDhg2xfv16JCUlYfDgwRgwYAA2b96sVdt//fUXPvjgA+zduxc7duzA3bt30bFjRyXOnJwcdOzYESqVCjt37sTu3buRl5eHbt26oaCgQOs+3Lx5E4GBgahRowb27duHf//9F5UrV0ZAQADu3r2r2wp5gn7o4s8//9RY302bNlWm7dmzB8HBwRgyZAgSEhLQo0cP9OjRA4cPH1bq5OTkoE2bNpg+fbrOy54+fToWLFiAefPm4dixY5g+fTpmzJiBb7/9VqlTq1YtzJs3D4cOHcK///4LNzc3dOzYEZcvXwYAtGrVSiP+1NRUvP3223B3d0ezZs0A3L/lfMeOHeHq6oq4uDh89dVXmDRpEhYuXKgsZ/Xq1Rg3bhzCwsJw7NgxLF68GBEREfj000+16ktERARCQkIQFhaG+Ph4NGrUCAEBAcjIyMClS5dw6dIlzJw5E4cPH8ayZcsQGRmJIUOG6LzOnpX9+/fjhx9+QMOGDXWed/369ejfvz8GDx6MgwcPYvfu3XjzzTeV6QYGBujevTs2btyIkydPYtmyZfjzzz8xdOhQpc6cOXM0tumFCxdgY2ODPn36aBXD22+/jR07dmDFihU4dOgQOnbsCH9/f1y8eBHA/eSmTZs2qFOnDqKjo5GUlIQJEyYoO35tfwtefvllrF27FidOnMD69etx+vRp9O7dW+d19qT9eJzRo0cX+X7UrVu3yHq0tLTUqHPu3LlS68P169fRunVrGBsb448//sDRo0cxa9YsWFtb69ROTEwMAgMD0bFjR8TGxmL//v0YPny48qgHbX4L8vPzYWZmhg8//BD+/v4696VevXoa7f/7779F6syePfuJHx+VkpKC7t2745VXXkFiYiK2bduGK1euoGfPnk/UnlaEHunmzZvSv39/sbCwEEdHR5k5c6a0a9dOPvroIzlx4oQAkMOHDyv18/Pzxc7OThYtWqSUnTx5Utq2bSumpqbi7e0t27dvFwDy66+/KnVcXV3lm2++0Sm2zp07y+DBg5+oXxkZGQJA/vrrLxER2bZtmxgYGEhWVpZSJzMzU1QqlezYsUMp27dvn/j4+Iipqak0bdpUNmzYIAAkISFBRET2798vAOT8+fPKPElJSQJAkpOTRURk6dKlYmVlJb/++qt4enqKqampdOzYUWOeJ+2HiMisWbOkfv36Ym5uLtWrV5dhw4bJjRs3lOkpKSkaMRfnjTfekC5dumiU+fr6ynvvvVekrjbtPaxLly7yv//9T6OsZ8+e8tZbb5U4T1ZWlgCQP//8s9jpeXl5YmdnJ59//rlS9t1334m1tbXk5uYqZWPHjpXatWsr7z/44AN55ZVXNNoKCQmR1q1ba9WXFi1ayAcffKC8z8/PF2dnZwkPDy+2/tq1a8XExETu3r2rlB06dEgCAwPFwsJC7O3tpV+/fnL58mVlert27eSDDz6QDz74QCwtLaVq1ary2WefSUFBgVLnzp07MmrUKHF2dhZzc3Np0aKF7Nq1S6s+FLpx44Z4eXnJjh07lO95ocd9j+/evSvVqlWTH3/8UadlzpkzR6pXr17i9F9//VVUKpWcPXv2sW3dunVLDA0NZfPmzRrlTZo0kfHjx4uISFBQkPTr16/ENrT9LXjY77//LiqVSvLy8kTk6b7n2vRD1+2dmJgoAOTvv/9WygpjfJSffvpJmjZtKpUqVRIHBwcJDg6W9PT0x/ZB5P53rU2bNo+s4+rqKp9//rn07dtXzM3NxdnZWebNm6dRx9fXVz777DOtlilS/G/BgwYOHCjdu3fXur2wsDBp1KjRI+skJCRItWrVJDU1tcj+TURky5Yt4uXlJWq1Wtq3by9Lly4VAHL9+nUREVm3bp0YGRlJfn6+Ms/GjRs1PlOFcXz//fdSvXp1MTMzkz59+khmZqbWfXkQjwA9xpgxY/DXX3/h999/x/bt2xEdHY34+HgAQG5uLgBoHDI1MDCAqampkh0XFBSgZ8+eMDExwb59+/D9999j7NixxS5r2rRpqFq1Kho3boyvvvoK9+7de2RsWVlZsLGxeaJ+FZ6CKJw/NzcXKpVK48ZUarUaBgYGSl9u3ryJrl27om7duoiLi8OkSZMwevRojXZr166NqlWrYvHixcjLy8Pt27exePFieHt7w83NTal369YtfPnll/jpp5+we/duZGZmom/fvk/dD+D+Npg7dy6OHDmC5cuXY+fOnfjkk0+KzPvaa6/B3t4ebdq0wcaNGzWmxcTEFPkrKSAgADExMTrHWJxWrVohKioKJ0+eBAAcPHgQ//77Lzp16lRs/by8PCxcuBBWVlZo1KhRsXU2btyIq1evYvDgwRr9eOmll2BiYqLRjxMnTuD69etKLHFxccppqzNnzmDr1q3o3LnzY/uRl5eHuLg4jXVlYGAAf3//EtdVVlYWLC0tYWR0/1GEmZmZeOWVV9C4cWMcOHAAkZGRSE9PxxtvvKEx3/Lly2FkZITY2FjMmTMHX3/9NX788Udl+vDhwxETE4M1a9YgKSkJffr00fmU9AcffIAuXboU2fbafI/j4+Nx8eJFGBgYoHHjxnByckKnTp00jho+7NKlS9iwYQPatWtXYp3FixfD398frq6uj43/3r17yM/PL3Iax8zMDP/++y8KCgqwZcsW1KpVCwEBAbC3t4evr6/G6Qptfgsedu3aNaxatQqtWrWCsbGxUv6k3/PH9QPQfXv/+OOPqFWrFtq2batRfvPmTbi6usLFxQXdu3fHkSNHNKbfvXsXU6ZMwcGDB/Hbb7/h7NmzGDRo0GP7ANz/TjZr1gx9+vSBvb09GjdujEWLFhWp99VXX6FRo0ZISEjAuHHj8NFHH2HHjh0AgIyMDOzbtw/29vZo1aoVHBwc0K5duxK3ReFyH/4teFrJyclwdnZGzZo18dZbb2mcMr116xbefPNNzJ8/H46OjkXmvXDhAnr27Ilu3bohMTERb7/9NsaNG6dRp2nTpjAwMMDSpUuRn5+PrKwsrFixAv7+/hqfqVOnTmHt2rXYtGkTIiMjkZCQgPfff//JOvVEaZOeuHHjhpiYmMjatWuVsqtXr4qZmZl89NFHkpeXJzVq1JA+ffrItWvXJDc3V6ZNmyYApGPHjiJy/68pIyMjuXjxotLGH3/8USRDnjVrluzatUsOHjwoCxYskCpVqsjHH39cYmwRERFiYmKicfRJW/n5+dKlSxeNv/AzMjLE0tJSPvroI8nJyZGbN2/K8OHDBYC8++67IiLyww8/SNWqVeX27dvKfAsWLChy9OPQoUPi4eEhBgYGYmBgILVr19b467Uw89+7d69SduzYMQEg+/bte6p+FGfdunVStWpV5f3ly5dl1qxZsnfvXomNjZWxY8eKSqWS33//XaljbGwsq1ev1mhn/vz5Ym9vX6T9JzkClJ+fryzXyMhIVCqVTJ06tUi9TZs2iYWFhahUKnF2dpbY2NgS2+zUqZN06tRJo+zVV19Vtl+hI0eOCAA5evSoUjZnzhwxNjYWIyMjASBDhw7Vqh8XL14UALJnzx6N8jFjxkiLFi2K1L98+bLUqFFDPv30U6VsypQpyvel0IULFwSAnDhxQkTuHwHy9vbWOOIzduxY8fb2FhGRc+fOiaGhocb3TESkQ4cOEhoaqlVffv75Z6lfv77y+X7wCJA23+Off/5ZAEiNGjXkl19+kQMHDkhwcLBUrVpVrl69qrGsvn37ipmZmQCQbt26aXynHnTx4kUxNDSUiIgIrfogIuLn5yft2rWTixcvyr1792TFihViYGAgtWrVUv46Nzc3l6+//loSEhIkPDxcVCqVREdHi4h2vwWFPvnkEzE3NxcA0rJlS7ly5Yoy7Wm/54/qh67b+/bt22JtbS3Tp0/XKN+zZ48sX75cEhISJDo6Wrp27SqWlpZy4cKFEuMqPMr94FHlkpiamoqpqamEhoZKfHy8/PDDD6JWq2XZsmVKHVdXVwkMDNSYLygoSPkux8TECACxsbGRJUuWSHx8vIwcOVJMTEzk5MmTxS63uN+CB+l6BGjr1q2ydu1aOXjwoERGRoqfn5/UqFFDsrOzRUTk3XfflSFDhij1H96/hYaGSt26dTXaHDt2rMYRIBGR6Ohosbe3F0NDQwEgfn5+GtPDwsLE0NBQ/vvvP6Xsjz/+EAMDA0lNTdW6P0qcOs+hRwoPmZ47d06j3MfHR/lhPHDggDRq1EgAiKGhoQQEBEinTp2UD/Ts2bPF3d1dY/7MzMxiDxE+aPHixWJkZCR37twpMm3nzp1ibm4uy5cvf6J+DR06VFxdXYt8ybdt2yY1a9YUlUolhoaG0q9fP2nSpImyMxw5cqS8/PLLGvMUrqPCnf+tW7ekRYsWMmDAAImNjZWYmBjp1auX1KtXT27duiUi938YHz7UKSJSpUoVjR+GJ+3Hjh075JVXXhFnZ2epVKmSqNVqASA5OTklttW/f3+NQ9VlnQD9/PPPUr16dfn5558lKSlJfvrpJ7GxsSnS/5s3b0pycrLExMTI//73P3Fzcyv28PuFCxfEwMBAfvnlF41ybRKgXbt2iYODgyxatEiSkpJkw4YN4uLiUuLh8wfpkgBlZWVJixYtJDAwUDmkLSLSu3dvMTY2FgsLC40XANm6dauI3E9GHj7d+9tvv4mRkZHcu3dPNm/eLACKtGFkZCRvvPHGY/tx/vx5sbe3l4MHDyplDyZA2nyPV61aJQDkhx9+UOrcuXNHbG1t5fvvv9eYNzU1VY4dOya///671K1bV4YNG1ZsXFOnTpWqVatqnMJ8nFOnTslLL72k/CY1b95c3nrrLalTp46yvYKDgzXm6datm/Tt21d5/7jfgkKXL1+WEydOyPbt26V169bSuXNnJUl92u/5o/qh6/ZevXq1GBkZSVpa2iOXmZeXJx4eHhqnmw4cOCBdu3YVFxcXqVSpkpLwHTly5LF9MDY2Fj8/P42yESNGSMuWLZX3rq6uMnnyZI06s2fPFjc3NxER2b17twAoktg1aNBAxo0bV2SZJf0WPEjXBOhh169fF0tLS/nxxx/l999/F09PT42E8OH9W48ePYr9/j6YAKWmpoqXl5eMGTNG4uPj5a+//pJ27dpJhw4dlM9UWFhYid/DwgReF0ZPdtyICjVt2hSJiYnIyspCXl4e7Ozs4Ovrqww8e1K+vr64d+8ezp49i9q1ayvlf/31F7p164ZvvvkGAwYM0Lnd4cOHY/Pmzfj7779RvXp1jWkdO3bE6dOnceXKFRgZGaFKlSpwdHREzZo1tW5/9erVOHv2LGJiYpQBeqtXr4a1tTV+//33JzrNpUs/zp49i65du2LYsGH48ssvYWNjg3///RdDhgxBXl4ezM3Ni23P19dXOeQMAI6OjkWueklPTy/28O6TGDNmDMaNG6esjwYNGuDcuXMIDw/HwIEDlXoWFhbw9PSEp6cnWrZsCS8vLyxevBihoaEa7S1duhRVq1bFa6+9plFeUj8KpwHAhAkT0L9/f7z99ttKLDk5OXj33Xcxfvx4ZTsWx9bWFoaGho9dVzdu3EBgYCAqV66MX3/9VeOQ9s2bN9GtW7diB5M7OTmVuOwH3bx5E4aGhoiLi4OhoaHGtEqVKj12/ri4OGRkZKBJkyZKWX5+Pv7++2/MmzcPs2bNemwbhbHWrVtXKTM1NUXNmjU1ThcA99e9o6Mj6tSpAxsbG7Rt2xYTJkzQ6K+IYMmSJejfv7/GKczH8fDwwF9//YWcnBxkZ2fDyckJQUFBqFmzJmxtbWFkZKQRIwB4e3trnFLR9rfA1tYWtra2qFWrFry9veHi4oK9e/fCz89P63ifpB+6bu8ff/wRXbt2hYODwyOXaWxsjMaNG+PUqVMA7g8IDwgIQEBAAFatWgU7OzucP38eAQEByMvLe2wfnJycil3X69evf+y8D7YBoNh2Hv5cASX/FpSmKlWqoFatWjh16hQOHTqE06dPF7nlQa9evdC2bVtER0dr1eb8+fNhZWWlcZXqypUr4eLign379qFly5al2IP7OAboETw8PGBsbKxx6fH169eVcRsPsrKygp2dHZKTk3HgwAF0794dwP0P6YULF5CamqrUffhy6+IkJibCwMAA9vb2Sll0dDS6dOmC6dOn491339WpLyKC4cOH49dff8XOnTvh7u5eYl1bW1tUqVIFO3fuREZGhvJF8vb2RlJSksbl0Q/35datWzAwMNC4EqDw/YNXkNy7d0/jUtATJ04gMzMT3t7eT9WPuLg4FBQUYNasWWjZsiVq1aql1aW5iYmJGjsfPz8/REVFadTZsWNHqfywA/+3nh5kaGj42CvuCgoKlLFnhUQES5cuxYABAzQSC+B+P/7++2+NK/B27NiB2rVrK1eilBRLYduPYmJigqZNm2qsq4KCAkRFRSnrqvBKNBMTE2zcuLHIuI4mTZrgyJEjcHNzU5K9wteDlyw/+D0E7n/2vLy8YGhoiMaNGyM/Px8ZGRlF2tAmae3QoQMOHTqExMRE5dWsWTO89dZbSExM1Op73LRpU5iammrcluHu3bs4e/bsI8fvFG7zh7frX3/9hVOnTj3xFXMWFhZwcnLC9evXsW3bNnTv3h0mJiZo3rx5kVtHnDx5stgYS/ot0LYfT/o9f1w/dNneKSkp2LVrl1brMT8/H4cOHVJ+C44fP46rV69i2rRpaNu2LerUqYOMjAytY2/durVW6/rhz9LevXuVdeTm5gZnZ2et2nnUb0FpunnzJk6fPg0nJyeMGzcOSUlJGt8dAPjmm2+wdOlSAPf3HYVjDAuVtO94UOHv0IO/i+fPn9f4Td+7dy8MDAw0DhRoTedjRnqm8DRLVFSUHDp0SF577TWpVKmScmh87dq1smvXLjl9+rT89ttv4urqKj179lTmz8/Pl7p168qrr74qiYmJ8vfff0vTpk01DhHu2bNHvvnmG0lMTJTTp0/LypUrxc7OTgYMGKC0U3jaKzQ0VFJTU5XXw2MLSjJs2DCxsrKS6OhojfkLT0uJiCxZskRiYmLk1KlTsmLFCrGxsZGQkBBl+o0bN8TW1lb69esnR44ckS1btoinp6fG6Z9jx46JqampDBs2TI4ePSqHDx+Wfv36iZWVlVy6dElE7h8aNzY2lhYtWsjevXvlwIED0rJlS43Dwk/aj8JTcrNnz5bTp0/LTz/9JNWqVdM41Lps2TJZvXq1HDt2TI4dOyZffvmlGBgYyJIlS5Tl7N69W4yMjGTmzJly7NgxCQsLE2NjYzl06JBS5+rVq5KQkCBbtmwRALJmzRpJSEjQ6lz0wIEDpVq1arJ582ZJSUmRDRs2iK2trXzyyScicv/UV2hoqMTExMjZs2flwIEDMnjwYDE1NS0y7uvPP/8UAHLs2LEiy8nMzBQHBwfp37+/HD58WNasWSPm5uYap2nCwsKkcuXK8vPPP8uZM2dk+/bt4uHhodWpIxGRNWvWiKmpqSxbtkyOHj0q7777rlSpUkXS0tIkKytLfH19pUGDBnLq1CmNbXbv3j0RuX8azc7OTnr37i2xsbFy6tQpiYyMlEGDBil12rVrJ5UqVZKPP/5Yjh8/LqtXrxYLCwuNU0tvvfWWuLm5yfr16+XMmTOyb98+mTp1apEribT14Ckwbb7HIiIfffSRVKtWTbZt2ybHjx+XIUOGiL29vVy7dk1E7l8Js2TJEjl06JCkpKTI5s2bxdvbu9hxbP369RNfX1+d446MjJQ//vhD2ZaNGjUSX19f5bTjhg0bxNjYWBYuXCjJycny7bffiqGhofzzzz9KG4/7Ldi7d698++23kpCQIGfPnpWoqChp1aqVeHh4KKftn+Z7rk0/tN3en332mTg7OyufpQdNnjxZtm3bJqdPn5a4uDjp27evqNVq5fRWRkaGmJiYyJgxY+T06dPy+++/S61atbQ+5R0bGytGRkby5ZdfSnJysqxatUrMzc1l5cqVSh1XV1extLSU6dOny4kTJ2TevHliaGgokZGRSp1vvvlGLC0tZd26dZKcnCyfffaZqNVqOXXqlMbyHvVbIHL/9HdCQoJ069ZN2rdvLwkJCVr1Y9SoURIdHS0pKSmye/du8ff3F1tbW8nIyCi2/sPfi3PnzomJiYmMHj1ajh8/LqtWrRJHR0eN3+WoqChRqVQyefJkOXnypMTFxUlAQIC4uroqv+9hYWFiYWEh/v7+yvewVq1aGqdvdcEE6DFu3Lgh/fr1E3Nzc3FwcJAZM2Zo/DAWXsJqbGwsNWrUkM8++6zI+foTJ05ImzZtxMTERGrVqiWRkZEaH5C4uDjx9fUVKysrUavV4u3tLVOnTtUY/zNw4EABUOTVrl07rfpR3LwAZOnSpUqdsWPHioODgxgbG4uXl5fMmjVLY9CpyP0BeY0aNRITExPx8fGR9evXF/kxKBwPYGVlJdbW1vLKK69ITEyMMr3w0tP169dLzZo1xdTUVPz9/YuMtXrSfnz99dfi5OQkZmZmEhAQID/99FORBMjb21vMzc3F0tJSWrRoIevWrSuyrLVr10qtWrXExMRE6tWrJ1u2bNGYXjjI8+FXWFjYY/uRnZ0tH330kdSoUUPUarXUrFlTxo8fr3x2bt++La+//ro4OzuLiYmJODk5yWuvvVbsIOjg4GBp1apVics6ePCgtGnTRkxNTaVatWoybdo0jel3796VSZMmiYeHh6jVanFxcZH3339fY/Dh43z77bdSo0YNMTExUXZ4IvfHF5W0zVJSUpT5T548Ka+//rpUqVJFzMzMpE6dOjJy5Ejl89euXTt5//33ZejQoWJpaSnW1tby6aefanw+8/LyZOLEieLm5ibGxsbi5OQkr7/+uiQlJWndjwc9fBn8477HhTGMGjVK7O3tpXLlyuLv76+RsO7cuVP8/PyU77qXl5eMHTu2yLrOzMwUMzMzWbhwoc5xR0RESM2aNcXExEQcHR3lgw8+KHKZ8OLFi8XT01PUarU0atRIfvvtN43pj/stSEpKkpdffllsbGzE1NRU3NzcZOjQoRqDU5/me65NP7TZ3vn5+VK9enWNQfcPGjlypPK5dXBwkM6dO0t8fLxGndWrV4ubm5uYmpqKn5+fbNy4Uacxf5s2bZL69euLqamp1KlTp8g2LRwD1KdPHzE3NxdHR0eZM2dOkXbCw8OlevXqYm5uLn5+fhoJa6HH/Ra4uroW+118nKCgIHFychITExOpVq2aBAUFFUm+HvTw90Lk/noovB1C27ZtZcmSJUUGQf/888/SuHFjsbCwEDs7O3nttdc0krnCy+C/++47cXZ2FrVaLb1791b+wNCV6v8HS0RERKQ3OAaIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivcMEiKicREdHQ6VSITMzs7xDeW5MmjQJPj4+JU7XZp0tW7asyIMZi7N48WJ07NhReT9o0CD06NFD+2CfU9r2v6K7cuUK7O3t8d9//5V3KPScYgJEei0/Px+tWrVCz549NcqzsrLg4uKC8ePHl9myW7VqhdTUVFhZWZXZMiZNmgSVSgWVSgVDQ0O4uLjg3XffxbVr18psmWWptNbZnTt3MGHCBISFhZVSZEWpVCr89ttvj63n5uambKPC17Rp08osrvKm7Xp5Wra2thgwYECZbmN6sTEBIr1maGiIZcuWITIyEqtWrVLKR4wYARsbmzL98TQxMYGjoyNUKlWZLQMA6tWrh9TUVJw/fx5Lly5FZGQkhg0bVqbLfJwHn06vi9JaZ7/88gssLS3RunXrp2qntHz++edITU1VXiNGjCjvkIp40m1WVrSJZ/DgwVi1atULm/BT2WICRHqvVq1amDZtGkaMGIHU1FT8/vvvWLNmDX766SeYmJiUON/YsWNRq1YtmJubo2bNmpgwYYLyoywi8Pf3R0BAAAoft3ft2jVUr14dEydOBFD0dM65c+fQrVs3WFtbw8LCAvXq1cPWrVufun9GRkZwdHREtWrV4O/vjz59+mDHjh0adX788Ud4e3tDrVajTp06+O677zSm//fffwgODoaNjQ0sLCzQrFkz7Nu3T5m+YMECeHh4wMTEBLVr18aKFSs05lepVFiwYAFee+01WFhY4MsvvwQATJs2DQ4ODqhcuTKGDBmCO3fuPLIvxZ0CW7ZsGWrUqAFzc3O8/vrruHr16mPXyZo1a9CtW7dH1omMjESbNm1QpUoVVK1aFV27dsXp06eV6Xl5eRg+fDicnJygVqvh6uqK8PBwAPeP6gDA66+/DpVKpbwvSeXKleHo6Ki8LCwsHlk/MzMT7733HhwcHKBWq1G/fn1s3rxZo862bdvg7e2NSpUqITAwEKmpqcq0/fv349VXX4WtrS2srKzQrl07xMfHa8xf3DbLz8/HkCFD4O7uDjMzM9SuXRtz5swpEt+SJUtQr149mJqawsnJCcOHD3/sevn999/RpEkTqNVq1KxZE5MnT8a9e/ceGc/169fx1ltvwc7ODmZmZvDy8sLSpUuVeerVqwdnZ2f8+uuvj1yfpKee6BGqRBVMQUGBtG/fXjp06CD29vYyZcqUx84zZcoU2b17t6SkpMjGjRvFwcFBpk+frkz/77//xNraWmbPni0iIn369JEWLVrI3bt3ReT/npRe+DTkLl26yKuvvipJSUly+vRp2bRpk/z1119P1a/CpycXSklJkXr16omDg4NStnLlSnFycpL169fLmTNnZP369WJjYyPLli0TEZEbN25IzZo1pW3btvLPP/9IcnKyREREyJ49e0REZMOGDWJsbCzz58+XEydOyKxZs8TQ0FB27typLAOA2Nvby5IlS+T06dNy7tw5iYiIEFNTU/nxxx/l+PHjMn78eKlcubJGvA97eJ3t3btXDAwMZPr06XLixAmZM2eOVKlSRaysrB65XqysrGTNmjUaZQMHDpTu3bsr73/55RdZv369JCcnS0JCgnTr1k0aNGgg+fn5IiLy1VdfiYuLi/z9999y9uxZ+eeff2T16tUiIpKRkSEAZOnSpZKamioZGRklxuLq6ioODg5iY2MjPj4+MmPGDOUzUpz8/Hxp2bKl1KtXT7Zv3658VrZu3Soi95/CbmxsLP7+/rJ//36Ji4sTb29vefPNN5U2oqKiZMWKFXLs2DE5evSoDBkyRBwcHCQ7O1upU9w2K3wC+/79++XMmTOycuVKMTc3l4iICGW+7777TtRqtcyePVtOnDghsbGx8s033zxyvfz9999iaWkpy5Ytk9OnT8v27dvFzc1NJk2a9Mh4PvjgA/Hx8ZH9+/dLSkqK7NixQzZu3KixvoKCgmTgwIElrk/SX0yAiP6/Y8eOCQBp0KDBI3dAJfnqq6+kadOmGmVr164VtVot48aNEwsLCzl58qQy7eGdeYMGDTR+8EtDWFiYGBgYiIWFhajVagEgAOTrr79W6nh4eCg77kJTpkwRPz8/ERH54YcfpHLlynL16tVil9GqVSt55513NMr69OkjnTt3Vt4DkJEjR2rU8fPzk/fff1+jzNfXV6cEKDg4WGM5Ivd3eI9KgK5fvy4A5O+//9YofzgBetjly5cFgBw6dEhEREaMGCGvvPKKFBQUFFsfgPz6668ltldo1qxZsmvXLjl48KAsWLBAqlSpIh9//HGJ9bdt2yYGBgZy4sSJYqcvXbpUAMipU6eUsvnz52skvQ/Lz8+XypUry6ZNmzTif3ibFeeDDz6QXr16Ke+dnZ1l/PjxJdYvbr106NBBpk6dqlG2YsUKcXJyemQ83bp1k8GDBz8yvo8//ljat2//uG6QHuIpMKL/b8mSJTA3N0dKSorGlSNDhw5FpUqVlFehiIgItG7dGo6OjqhUqRI+++wznD9/XqPNPn364PXXX8e0adMwc+ZMeHl5lbj8Dz/8EF988QVat26NsLAwJCUllVh36tSpGjE9vNwH1a5dG4mJidi/fz/Gjh2LgIAAZYxJTk4OTp8+jSFDhmi098UXXyinexITE9G4cWPY2NgU2/6xY8eKjKVp3bo1jh07plHWrFmzIvP5+vpqlPn5+ZXYj5KWrWsbt2/fBgCo1epH1ktOTkZwcDBq1qwJS0tL5XRN4boeNGgQEhMTUbt2bXz44YfYvn27TrEXCgkJQfv27dGwYUMMHToUs2bNwrfffovc3Nxi6ycmJqJ69eqoVatWiW2am5vDw8NDee/k5ISMjAzlfXp6Ot555x14eXnBysoKlpaWuHnzZpHP0cPbDADmz5+Ppk2bws7ODpUqVcLChQuV+TIyMnDp0iV06NBBp3Vw8OBBfP755xqfwXfeeQepqam4detWifEMGzYMa9asgY+PDz755BPs2bOnSNtmZmYabRAVYgJEBGDPnj345ptvsHnzZrRo0QJDhgxRxu58/vnnSExMVF4AEBMTg7feegudO3fG5s2bkZCQgPHjxyMvL0+j3Vu3biEuLg6GhoZITk5+ZAxvv/02zpw5g/79++PQoUNo1qwZvv3222LrDh06VCMmZ2fnEts1MTGBp6cn6tevj2nTpsHQ0BCTJ08GANy8eRMAsGjRIo32Dh8+jL179wK4vwMpDY8b1/KsVK1aFSqVCtevX39kvW7duuHatWtYtGgR9u3bp4x5KtzGTZo0QUpKCqZMmYLbt2/jjTfeQO/evZ86Pl9fX9y7dw9nz54tdro228PY2FjjvUqlUj7PADBw4EAkJiZizpw52LNnDxITE1G1atUin9+Ht9maNWswevRoDBkyBNu3b0diYiIGDx6szPekn5WbN29i8uTJGp/BQ4cOITk5WSNRfTieTp064dy5c/j444+VxGv06NEada5duwY7O7sniosqNiZApPdu3bqFQYMGYdiwYXj55ZexePFixMbG4vvvvwcA2Nvbw9PTU3kB9xMmV1dXjB8/Hs2aNYOXlxfOnTtXpO1Ro0bBwMAAf/zxB+bOnYudO3c+MhYXFxcMHToUGzZswKhRo7Bo0aJi69nY2GjEZGRkpHV/P/vsM8ycOROXLl2Cg4MDnJ2dcebMGY32PD094e7uDgBo2LAhEhMTS7ySxtvbG7t379Yo2717N+rWrfvIOLy9vTUGUgNQki5tPUkbJiYmqFu3Lo4ePVpinatXr+LEiRP47LPP0KFDB3h7exebMFlaWiIoKAiLFi1CREQE1q9fr6wnY2Nj5Ofn69Qf4P4RHgMDA9jb2xc7vWHDhvjvv/9w8uRJndsutHv3bnz44Yfo3LmzMlj5ypUrWs3XqlUrvP/++2jcuDE8PT01BoZXrlwZbm5uiIqKKrGN4tZLkyZNcOLEiSKfQU9PTxgYPHo3ZWdnh4EDB2LlypWYPXs2Fi5cqDH98OHDaNy48WP7RvpH+19NogoqNDQUIqLce8XNzQ0zZ87E6NGj0alTp2Kv4PHy8sL58+exZs0aNG/eHFu2bClypcmWLVuwZMkSxMTEoEmTJhgzZgwGDhyIpKQkWFtbF2lz5MiR6NSpE2rVqoXr169j165d8Pb2LvX++vn5oWHDhpg6dSrmzZuHyZMn48MPP4SVlRUCAwORm5uLAwcO4Pr16wgJCUFwcDCmTp2KHj16IDw8HE5OTkhISICzszP8/PwwZswYvPHGG2jcuDH8/f2xadMmbNiwAX/++ecj4/joo48waNAgNGvWDK1bt8aqVatw5MgR1KxZU+u+fPjhh2jdujVmzpyJ7t27Y9u2bYiMjHzsfAEBAfj3338xcuTIYqdbW1ujatWqWLhwIZycnHD+/HmMGzdOo87XX38NJycnNG7cGAYGBli3bh0cHR2VmxAWJgKtW7eGqalpsds8JiYG+/btw8svv4zKlSsjJiYGH3/8Mfr161dsfQBo164dXnrpJfTq1Qtff/01PD09cfz4cahUKgQGBj6278D9z++KFSvQrFkzZGdnY8yYMVodvfHy8sJPP/2Ebdu2wd3dHStWrMD+/fuVZBm4f++poUOHwt7eHp06dcKNGzewe/du5bRrcetl4sSJ6Nq1K2rUqIHevXvDwMAABw8exOHDh/HFF1+UGM/EiRPRtGlT1KtXD7m5udi8ebPGd6bwCOzUqVO1Wi+kZ8p5DBJRuYqOjhZDQ0P5559/ikzr2LHjIwe5jhkzRqpWrSqVKlWSoKAg+eabb5TBtxkZGeLg4KAxsDMvL0+aNm0qb7zxhogUHdA7fPhw8fDwEFNTU7Gzs5P+/fvLlStXnqp/D18FVujnn38WU1NTOX/+vIiIrFq1Snx8fMTExESsra3lpZdekg0bNij1z549K7169RJLS0sxNzeXZs2ayb59+5Tp3333ndSsWVOMjY2lVq1a8tNPP2ksDyUMCP7yyy/F1tZWKlWqJAMHDpRPPvlEp0HQIiKLFy+W6tWri5mZmXTr1k1mzpz52KvAjhw5ImZmZpKZmamUPTwIeseOHeLt7S2mpqbSsGFDiY6O1ujHwoULxcfHRywsLMTS0lI6dOgg8fHxyvwbN24UT09PMTIyEldX12LjiIuLE19fX7GyshK1Wi3e3t4ydepUuXPnziPjv3r1qgwePFiqVq0qarVa6tevL5s3bxaR+4OgH+7/r7/+Kg/+3MfHx0uzZs1ErVaLl5eXrFu3TlxdXZWrtUSK32Z37tyRQYMGiZWVlVSpUkWGDRsm48aNK7LNvv/+e6ldu7YYGxuLk5OTjBgx4rHrJTIyUlq1aiVmZmZiaWkpLVq0kIULFz4ynilTpoi3t7eYmZmJjY2NdO/eXc6cOaNMX716tdSuXfuR65L0l0rkgRPDRER6ok+fPmjSpAlCQ0PLOxQqIy1btsSHH36IN998s7xDoecQxwARkV766quvNK7qo4rlypUr6NmzJ4KDg8s7FHpO8QgQERER6R0eASIiIiK9wwSIiIiI9A4TICIiItI7TICIiIhI7zABIiIiIr3DBIiIiIj0DhMgIiIi0jtMgIiIiEjvMAEiIiIivfP/AA2lB6D58548AAAAAElFTkSuQmCC"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 66
   },
   {
    "cell_type": "markdown",
@@ -1814,9 +3204,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:37.702210Z",
+     "start_time": "2024-09-18T13:52:37.497548Z"
+    }
+   },
    "source": [
     "import matplotlib.pyplot as plt\n",
     "plt.scatter(x, y_rougelsum, marker='o')\n",
@@ -1828,7 +3221,20 @@
     "\n",
     "# Display the graph\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkAAAAHHCAYAAABXx+fLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAABpoUlEQVR4nO3deXxM1/8/8NdMtsk6SWQnkogg1lgj9pJKbKVK0arlQ1uUVqNKqoRqbaVVpdSuloqWVtEGDaElBEnEXiKWksWWxFIJyfv3h1/u10jCDIlgXs/HYx7Mueee+z733pl5595z71WJiICIiIjIiKjLOgAiIiKip40JEBERERkdJkBERERkdJgAERERkdFhAkRERERGhwkQERERGR0mQERERGR0mAARERGR0WECREREREaHCRARPbbx48dDpVKVdRhUwlq1aoVWrVo9sp63tzf69ev3yHpLly6FSqXCmTNnnjg2opLCBIiIiIiMjmlZB0BERM+nEydOQK3m39H0fOKeS/SMuXnzZlmHQCXsWdumJRWPhYUFzMzMSqQtoqeNCRBRGSoYQ3P06FG88cYbcHBwQLNmzQAAd+/excSJE+Hr6wsLCwt4e3vjk08+QU5Ojk4bKpUK48ePL9R2UeMzkpKS0LJlS1haWqJChQr4/PPPsWTJkiLHZ/zxxx9o3rw5rK2tYWtriw4dOuDIkSOP7NPWrVvRrFkz2Nvbw8bGBlWrVsUnn3yiTC9uPEhMTAxUKhViYmKUslatWqFmzZpK3FZWVqhcuTJ+/vlnAMCOHTsQGBgIS0tLVK1aFX/++edDY0tPT4epqSkmTJhQaNqJEyegUqkwe/ZsAMCdO3cwYcIE+Pn5QaPRoFy5cmjWrBm2bt360GUU9G/Hjh0YMmQIXFxcUKFCBWW6vuv1+PHjeP311+Hs7Kz0b8yYMTp1EhIS0K5dO9jZ2cHGxgZt2rTBnj17DIpn/vz58PX1haWlJRo1aoS//vrrof27X1H72JEjR9C6dWudfSw/P1/vNomeFp4CI3oGdO/eHX5+fpg0aRJEBAAwcOBALFu2DN26dcOIESOwd+9eTJ48GceOHcMvv/xi8DIuXLiAl156CSqVCuHh4bC2tsbChQthYWFRqO7y5cvRt29fhISEYOrUqbh16xbmzp2LZs2aISEhAd7e3kUu48iRI+jYsSNq166Nzz77DBYWFjh16hR27dplcLwFrl27ho4dO6Jnz57o3r075s6di549e2LlypUYPnw4Bg0ahDfeeANffvklunXrhvPnz8PW1rbItlxdXdGyZUusWbMGEREROtMiIyNhYmKC7t27A7iXnE6ePBkDBw5Eo0aNkJ2djf379yM+Ph4vv/zyI+MeMmQInJ2dMW7cOOWIi77rNSkpCc2bN4eZmRneeecdeHt7Izk5GRs2bMAXX3wB4N66bt68Oezs7PDxxx/DzMwM33//PVq1aqUkho+KZ9GiRXj33XfRpEkTDB8+HKdPn8Yrr7wCR0dHeHp66r+R/r+0tDS89NJLuHv3LkaPHg1ra2vMnz8flpaWBrdFVOqEiMpMRESEAJBevXrplCcmJgoAGThwoE75Rx99JABk27ZtShkAiYiIKNS2l5eX9O3bV3k/bNgwUalUkpCQoJRduXJFHB0dBYCkpKSIiMj169fF3t5e3n77bZ320tLSRKvV6pQXxF/g66+/FgBy6dKlYvu8ZMkSneUV2L59uwCQ7du3K2UtW7YUALJq1Sql7Pjx4wJA1Gq17NmzRynfvHmzAJAlS5YUu2wRke+//14AyKFDh3TKq1evLq1bt1be16lTRzp06PDQth7Wv2bNmsndu3eVckPWa4sWLcTW1lbOnj2rUzc/P1/5f5cuXcTc3FySk5OVsosXL4qtra20aNHikfHk5uaKi4uLBAQESE5OjlI+f/58ASAtW7Z8ZF8f3MeGDx8uAGTv3r1KWUZGhmi12iK3OVFZ4ikwomfAoEGDdN7//vvvAICwsDCd8hEjRgAANm3aZPAyoqKiEBQUhICAAKXM0dERb775pk69rVu3IjMzE7169cLly5eVl4mJCQIDA7F9+/Zil2Fvbw8AWL9+fYmd9rCxsUHPnj2V91WrVoW9vT38/f11jnIU/P/06dMPba9r164wNTVFZGSkUnb48GEcPXoUPXr0UMrs7e1x5MgRnDx58rHifvvtt2FiYqK813e9Xrp0CTt37sT//vc/VKxYUafNglsO5OXlYcuWLejSpQsqVaqkTHd3d8cbb7yBv//+G9nZ2Q+NZ//+/cjIyMCgQYNgbm6ulPfr1w9arfax+vz777+jcePGaNSokVLm7OxcaB8jehYwASJ6Bvj4+Oi8P3v2LNRqNSpXrqxT7ubmBnt7e5w9e9bgZZw9e7ZQewAKlRX84Ldu3RrOzs46ry1btiAjI6PYZfTo0QNNmzbFwIED4erqip49e2LNmjVPlAxVqFCh0L2GtFptoVM0BT/a165de2h7Tk5OaNOmDdasWaOURUZGwtTUFF27dlXKPvvsM2RmZqJKlSqoVasWRo4ciaSkJL3jfnCb6rteCxK4mjVrFtv2pUuXcOvWLVStWrXQNH9/f+Tn5+P8+fMPjadgH/Lz89MpNzMz00mqDHH27NlC7QEoMk6issYxQETPgOLGSDzJTQbz8vIea76CZGX58uVwc3MrNN3UtPivDUtLS+zcuRPbt2/Hpk2bEBUVhcjISLRu3RpbtmyBiYlJsX0qLt77j1roUy7/fwzVw/Ts2RP9+/dHYmIiAgICsGbNGrRp0wZOTk5KnRYtWiA5ORnr16/Hli1bsHDhQnz99deYN28eBg4c+MhlPLhNn2S9lgSOwyHSxQSI6Bnk5eWF/Px8nDx5Ev7+/kp5eno6MjMz4eXlpZQ5ODggMzNTZ/7c3FykpqYWavPUqVOFlvVgma+vLwDAxcUFwcHBBseuVqvRpk0btGnTBl999RUmTZqEMWPGYPv27QgODoaDgwMAFIr5cY5qPa4uXbrg3XffVU6D/fPPPwgPDy9Uz9HREf3790f//v1x48YNtGjRAuPHj9crAXqQvuu14OjL4cOHi63j7OwMKysrnDhxotC048ePQ61WP3IQc8E+dPLkSbRu3Vopv3PnDlJSUlCnTp2Hzl9cm0WdMiwqTqKyxlNgRM+g9u3bAwBmzpypU/7VV18BADp06KCU+fr6YufOnTr15s+fX+iISkhICGJjY5GYmKiUXb16FStXrixUz87ODpMmTcKdO3cKxXbp0qVi47569WqhsoIxRwWX7xckAvfHnJeXh/nz5xfbbkmzt7dHSEgI1qxZg9WrV8Pc3BxdunTRqXPlyhWd9zY2NqhcuXKh2xDoS9/16uzsjBYtWmDx4sU4d+6cTp2Co1smJiZo27Yt1q9fr3M7gfT0dKxatQrNmjWDnZ3dQ+Np0KABnJ2dMW/ePOTm5irlS5cuLZSc6qt9+/bYs2cP4uLidPr14D5G9CzgESCiZ1CdOnXQt29fzJ8/H5mZmWjZsiXi4uKwbNkydOnSBS+99JJSd+DAgRg0aBBee+01vPzyyzh48CA2b96sczoHAD7++GOsWLECL7/8MoYNG6ZcBl+xYkVcvXpVOTVlZ2eHuXPn4q233kK9evXQs2dPODs749y5c9i0aROaNm2q3CvnQZ999hl27tyJDh06wMvLCxkZGfjuu+9QoUIF5f5GNWrUQOPGjREeHo6rV6/C0dERq1evxt27d0tpbRatR48e6N27N7777juEhIQoA7gLVK9eHa1atUL9+vXh6OiI/fv34+eff8bQoUMfa3mGrNdZs2ahWbNmqFevHt555x34+PjgzJkz2LRpk5LAfv7558o9l4YMGQJTU1N8//33yMnJwbRp0x4Zj5mZGT7//HO8++67aN26NXr06IGUlBQsWbLksccAffzxx1i+fDlCQ0PxwQcfKJfBe3l5GTR+iuipKOvL0IiMWcFl5EVdNn7nzh2ZMGGC+Pj4iJmZmXh6ekp4eLjcvn1bp15eXp6MGjVKnJycxMrKSkJCQuTUqVOFLlEWEUlISJDmzZuLhYWFVKhQQSZPniyzZs0SAJKWlqZTd/v27RISEiJarVY0Go34+vpKv379ZP/+/YXiLxAdHS2dO3cWDw8PMTc3Fw8PD+nVq5f8888/Om0nJydLcHCwWFhYiKurq3zyySeydevWIi+Dr1GjRqF14+XlVeQl6gDkvffeK7yii5CdnS2WlpYCQFasWFFo+ueffy6NGjUSe3t7sbS0lGrVqskXX3whubm5D2234LLzffv2FTldn/UqInL48GF59dVXxd7eXjQajVStWlXGjh2rUyc+Pl5CQkLExsZGrKys5KWXXpLdu3cbFM93330nPj4+YmFhIQ0aNJCdO3dKy5YtH+syeBGRpKQkadmypWg0GilfvrxMnDhRFi1axMvg6ZmjEtFjxCARvbCGDx+O77//Hjdu3Ch2YDER0YuGY4CIjMh///2n8/7KlStYvnw5mjVrxuSHiIwKxwARGZGgoCC0atUK/v7+SE9Px6JFi5CdnY2xY8eWdWhERE8VEyAiI9K+fXv8/PPPmD9/PlQqFerVq4dFixahRYsWZR0aEdFTxTFAREREZHQ4BoiIiIiMDhMgIiIiMjocA1SE/Px8XLx4Eba2tk/0LCYiIiJ6ekQE169fh4eHB9Tqhx/jYQJUhIsXLz7yOTpERET0bDp//jwqVKjw0DpMgIpga2sL4N4KfNTzdIiIiOjZkJ2dDU9PT+V3/GGYABXh/mciMQEiIiJ6vugzfIWDoImIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOg8EwnQnDlz4O3tDY1Gg8DAQMTFxRVbd926dWjQoAHs7e1hbW2NgIAALF++XKeOiGDcuHFwd3eHpaUlgoODcfLkydLuBhERET0nyjwBioyMRFhYGCIiIhAfH486deogJCQEGRkZRdZ3dHTEmDFjEBsbi6SkJPTv3x/9+/fH5s2blTrTpk3DrFmzMG/ePOzduxfW1tYICQnB7du3n1a3iIiI6BlW5k+DDwwMRMOGDTF79mwA9x5D4enpiWHDhmH06NF6tVGvXj106NABEydOhIjAw8MDI0aMwEcffQQAyMrKgqurK5YuXYqePXs+sr3s7GxotVpkZWXxPkBERETPCUN+v8v0CFBubi4OHDiA4OBgpUytViM4OBixsbGPnF9EEB0djRMnTqBFixYAgJSUFKSlpem0qdVqERgYqFebRERE9OIr0ztBX758GXl5eXB1ddUpd3V1xfHjx4udLysrC+XLl0dOTg5MTEzw3Xff4eWXXwYApKWlKW082GbBtAfl5OQgJydHeZ+dnf1Y/XmUvHxBXMpVZFy/DRdbDRr5OMJEzYetEhHRw/H3o+Q9l4/CsLW1RWJiIm7cuIHo6GiEhYWhUqVKaNWq1WO1N3nyZEyYMKFkg3xA1OFUTNhwFKlZ/zcOyV2rQUSn6git6V6qyyYioucXfz9KR5meAnNycoKJiQnS09N1ytPT0+Hm5lbsfGq1GpUrV0ZAQABGjBiBbt26YfLkyQCgzGdIm+Hh4cjKylJe58+ff5JuFRJ1OBWDV8Tr7LwAkJZ1G4NXxCPqcGqJLo+IiF4M/P0oPWWaAJmbm6N+/fqIjo5WyvLz8xEdHY2goCC928nPz1dOYfn4+MDNzU2nzezsbOzdu7fYNi0sLJQHn5b0A1Dz8gUTNhxFUSPNC8ombDiKvPwyHYtORETPGP5+lK4yPwUWFhaGvn37okGDBmjUqBFmzpyJmzdvon///gCAPn36oHz58soRnsmTJ6NBgwbw9fVFTk4Ofv/9dyxfvhxz584FcO8JsMOHD8fnn38OPz8/+Pj4YOzYsfDw8ECXLl2eev/iUq4WytzvJwBSs24jLuUqgnzLPb3AiIjomcbfj9JV5glQjx49cOnSJYwbNw5paWkICAhAVFSUMoj53LlzUKv/70DVzZs3MWTIEPz777+wtLREtWrVsGLFCvTo0UOp8/HHH+PmzZt45513kJmZiWbNmiEqKgoajeap9y/jun73HtK3HhERGQf+fpSuMr8P0LOoJO8DFJt8Bb0W7HlkvR/fbswMnoiIFPz9MNxzcx8gY9DIxxHuWg2Ku1hRhXuj+Rv5OD7NsIiI6BnH34/SxQSolJmoVYjoVB0ACu3EBe8jOlXn/RyIiEgHfz9KFxOgpyC0pjvm9q4HN63uGCQ3rQZze9fjfRyIiKhI/P0oPRwDVITSehYY7+RJRESPg78f+jHk97vMrwIzJiZqFQeqERGRwfj7UfJ4CoyIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIzOM5EAzZkzB97e3tBoNAgMDERcXFyxdRcsWIDmzZvDwcEBDg4OCA4OLlS/X79+UKlUOq/Q0NDS7gYRERE9J8o8AYqMjERYWBgiIiIQHx+POnXqICQkBBkZGUXWj4mJQa9evbB9+3bExsbC09MTbdu2xYULF3TqhYaGIjU1VXn9+OOPT6M7RERE9BxQiYiUZQCBgYFo2LAhZs+eDQDIz8+Hp6cnhg0bhtGjRz9y/ry8PDg4OGD27Nno06cPgHtHgDIzM/Hrr78+VkzZ2dnQarXIysqCnZ3dY7VBRERET5chv99legQoNzcXBw4cQHBwsFKmVqsRHByM2NhYvdq4desW7ty5A0dHR53ymJgYuLi4oGrVqhg8eDCuXLlSbBs5OTnIzs7WeREREdGLq0wToMuXLyMvLw+urq465a6urkhLS9OrjVGjRsHDw0MniQoNDcUPP/yA6OhoTJ06FTt27EC7du2Ql5dXZBuTJ0+GVqtVXp6eno/fKSIiInrmmZZ1AE9iypQpWL16NWJiYqDRaJTynj17Kv+vVasWateuDV9fX8TExKBNmzaF2gkPD0dYWJjyPjs7m0kQERHRC6xMjwA5OTnBxMQE6enpOuXp6elwc3N76LzTp0/HlClTsGXLFtSuXfuhdStVqgQnJyecOnWqyOkWFhaws7PTeREREdGLq0wTIHNzc9SvXx/R0dFKWX5+PqKjoxEUFFTsfNOmTcPEiRMRFRWFBg0aPHI5//77L65cuQJ3d/cSiZuIiIieb2V+GXxYWBgWLFiAZcuW4dixYxg8eDBu3ryJ/v37AwD69OmD8PBwpf7UqVMxduxYLF68GN7e3khLS0NaWhpu3LgBALhx4wZGjhyJPXv24MyZM4iOjkbnzp1RuXJlhISElEkfiYiI6NlS5mOAevTogUuXLmHcuHFIS0tDQEAAoqKilIHR586dg1r9f3na3LlzkZubi27duum0ExERgfHjx8PExARJSUlYtmwZMjMz4eHhgbZt22LixImwsLB4qn0jIiKiZ1OZ3wfoWcT7ABERET1/npv7ABERERGVBSZAREREZHSYABEREZHRYQJERERERocJEBERERkdJkBERERkdJgAERERkdFhAkRERERGhwkQERERGR0mQERERGR0mAARERGR0WECREREREaHCRAREREZHSZAREREZHSYABEREZHRYQJERERERocJEBERERkdJkBERERkdJgAERERkdFhAkRERERGhwkQERERGR0mQERERGR0mAARERGR0WECREREREaHCRAREREZHSZAREREZHSYABEREZHRYQJERERERocJEBERERkdJkBERERkdJgAERERkdFhAkRERERGhwkQERERGR0mQERERGR0mAARERGR0WECREREREaHCRAREREZHSZAREREZHSYABEREZHRYQJERERERsdU34qfffaZXvXGjRv32MEQERERPQ0qERF9KqrVanh4eMDFxQXFzaJSqRAfH1+iAZaF7OxsaLVaZGVlwc7OrqzDISIiIj0Y8vut9xGgdu3aYdu2bWjQoAH+97//oWPHjlCreQaNiIiInj96ZzCbNm1CcnIyAgMDMXLkSJQvXx6jRo3CiRMnSjM+IiIiohJn0CEcDw8PhIeH48SJE4iMjERGRgYaNmyIpk2b4r///iutGImIiIhKlN6nwB7UsGFDnDlzBkePHkVCQgLu3LkDS0vLkoyNiIiIqFQYPIgnNjYWb7/9Ntzc3PDtt9+ib9++uHjx4hMNFp4zZw68vb2h0WgQGBiIuLi4YusuWLAAzZs3h4ODAxwcHBAcHFyovohg3LhxcHd3h6WlJYKDg3Hy5MnHjo+IiIheLHonQNOmTUP16tXRuXNn2NjY4K+//sK+ffswZMgQ2NvbP3YAkZGRCAsLQ0REBOLj41GnTh2EhIQgIyOjyPoxMTHo1asXtm/fjtjYWHh6eqJt27a4cOGCTqyzZs3CvHnzsHfvXlhbWyMkJAS3b99+7DiJiIjoxWHQZfAVK1ZEx44dYW5uXmy9r776yqAAAgMD0bBhQ8yePRsAkJ+fD09PTwwbNgyjR49+5Px5eXlwcHDA7Nmz0adPH4gIPDw8MGLECHz00UcAgKysLLi6umLp0qXo2bPnI9vkZfBERETPn1K5DL5FixZQqVQ4cuRIsXVUKpX+UQLIzc3FgQMHEB4erpSp1WoEBwcjNjZWrzZu3bqFO3fuwNHREQCQkpKCtLQ0BAcHK3W0Wi0CAwMRGxtbZAKUk5ODnJwc5X12drZB/SAiIqLni94JUExMTIkv/PLly8jLy4Orq6tOuaurK44fP65XG6NGjYKHh4eS8KSlpSltPNhmwbQHTZ48GRMmTDA0fCIiInpOPdd3MpwyZQpWr16NX375BRqN5rHbCQ8PR1ZWlvI6f/58CUZJREREzxq9jwB17dq1yHKtVosqVapg4MCBcHZ2NmjhTk5OMDExQXp6uk55eno63NzcHjrv9OnTMWXKFPz555+oXbu2Ul4wX3p6Otzd3XXaDAgIKLItCwsLWFhYGBQ7ERERPb/0PgKk1WqLfGVmZmLBggWoWrUqDh8+bNDCzc3NUb9+fURHRytl+fn5iI6ORlBQULHzTZs2DRMnTkRUVBQaNGigM83Hxwdubm46bWZnZ2Pv3r0PbZOIiIiMh95HgJYsWVLstPz8fLz99tsIDw/Hhg0bDAogLCwMffv2RYMGDdCoUSPMnDkTN2/eRP/+/QEAffr0Qfny5TF58mQAwNSpUzFu3DisWrUK3t7eyrgeGxsb2NjYQKVSYfjw4fj888/h5+cHHx8fjB07Fh4eHujSpYtBsREREdGL6bHvBH0/tVqN999/H+3atTN43h49euDSpUsYN24c0tLSEBAQgKioKGUQ87lz53Qeujp37lzk5uaiW7duOu1ERERg/PjxAICPP/4YN2/exDvvvIPMzEw0a9YMUVFRTzROiIiIiF4cet8H6FFOnTqFBg0aIDMzsySaK1O8DxAREdHzx5Df7xK7Cmzr1q2oUqVKSTVHREREVGr0PgX222+/FVmelZWFAwcOYOHChVi4cGGJBUZERERUWvROgIobQGxra4uqVati4cKFej1mgoiIiKis6Z0A5efnl2YcRERERE/Nc30naCIiIqLHoXcCFBsbi40bN+qU/fDDD/Dx8YGLiwveeecdnQeKEhERET2r9E6APvvsM50nwR86dAgDBgxAcHAwRo8ejQ0bNig3KyQiIiJ6lumdACUmJqJNmzbK+9WrVyMwMBALFixAWFgYZs2ahTVr1pRKkEREREQlSe8E6Nq1a8rdmQFgx44dOnd+btiwIZ+iTkRERM8FvRMgV1dXpKSkAAByc3MRHx+Pxo0bK9OvX78OMzOzko+QiIiIqITpnQC1b98eo0ePxl9//YXw8HBYWVmhefPmyvSkpCT4+vqWSpBEREREJUnv+wBNnDgRXbt2RcuWLWFjY4Nly5bB3Nxcmb548WK0bdu2VIIkIiIiKkkGPww1KysLNjY2MDEx0Sm/evUqbG1tX4jTYHwYKhER0fOnVB+GqtVqCyU/AJCRkYEaNWoY2hwRERHRU1did4LOyclBcnJySTVHREREVGr4KAwiIiIyOkyAiIiIyOgwASIiIiKjo/dl8A4ODlCpVMVOv3v3bokERERERFTa9E6Avv7664cmQERERETPC70ToH79+pViGERERERPj95jgOLi4pCXl1fs9JycHD4NnoiIiJ4LeidAQUFBuHLlivLezs4Op0+fVt5nZmaiV69eJRsdERERUSnQOwF68IkZRT1Bw8CnahARERGViRK9DJ6DpImIiOh5wPsAERERkdHR+yowADh69CjS0tIA3Dvddfz4cdy4cQMAcPny5ZKPjoiIiKgUqETPgTtqtRoqlarIcT4F5SqV6qFXij0vsrOzodVqkZWVBTs7u7IOh4iIiPRgyO+33keAUlJSnjgwIiIiomeB3gmQl5dXacZBRERE9NQYNAYoOztbOaT0+++/6zz/y8TEBB06dCjZ6IiIiIhKgd4J0MaNGzF27FgkJCQAAHr06IGbN28q01UqFSIjI9GtW7eSj5KIiIioBOl9Gfz8+fMxbNgwnbJTp04hPz8f+fn5mDx5MhYvXlziARIRERGVNL0ToEOHDqFp06bFTm/Xrh32799fIkERERERlSa9E6DU1FRYWFgo77dv3w5PT0/lvY2NDbKysko2OiIiIqJSoHcC5OjoiFOnTinvGzRoADMzM+X9yZMn4ejoWLLREREREZUCvROgFi1aYNasWcVOnzVrFlq0aFEiQRERERGVJr0ToFGjRmHLli3o3r079u3bh6ysLGRlZSEuLg6vvfYa/vzzT4waNao0YyUiIiIqEXpfBl+3bl1ERkZi4MCBWLdunc40BwcHrF69GvXq1SvxAImIiIhKmt7PAitw69YtbN68GSdPngQA+Pn5oW3btrC2ti6VAMsCnwVGRET0/CmVZ4EVsLKywquvvvrYwRERERGVNb0ToLCwsCLLtVotqlSpgq5du+pcJk9ERET0rNI7ASp4BMaDMjMzcerUKYwdOxbbtm1DxYoVSyw4IiIiotJg8BigomRnZ+PNN9+Era0tVq1aVRJxlSmOASIiInr+GPL7rfdl8A9jZ2eHsWPHYteuXSXRHBEREVGpKpEECACcnJxw9erVkmqOiIiIqNSUWAK0Z88e+Pr6GjzfnDlz4O3tDY1Gg8DAQMTFxRVb98iRI3jttdfg7e0NlUqFmTNnFqozfvx4qFQqnVe1atUMjouIiIheXHoPgk5KSiqyPCsrCwcOHMCkSZMQERFh0MIjIyMRFhaGefPmITAwEDNnzkRISAhOnDgBFxeXQvVv3bqFSpUqoXv37vjwww+LbbdGjRr4888/lfempgZf7U9EREQvML0zg4CAAKhUKhQ1ZtrJyQlhYWEYMmSIQQv/6quv8Pbbb6N///4AgHnz5mHTpk1YvHgxRo8eXah+w4YN0bBhQwAocnoBU1NTuLm5GRQLERERGQ+9E6CUlJQiy+3s7ODg4GDwgnNzc3HgwAGEh4crZWq1GsHBwYiNjTW4vfudPHkSHh4e0Gg0CAoKwuTJkx96eX5OTg5ycnKU99nZ2U+0fCIiInq26Z0AeXl5leiCL1++jLy8PLi6uuqUu7q64vjx44/dbmBgIJYuXYqqVasiNTUVEyZMQPPmzXH48GHY2toWOc/kyZMxYcKEx14mERERPV8MHgT9008/oWvXrqhZsyZq1qyJrl274ueffy6N2B5Lu3bt0L17d9SuXRshISH4/fffkZmZiTVr1hQ7T3h4uPJ0+6ysLJw/f/4pRkxERERPm94JUH5+Pnr06IEePXrg6NGjqFy5MipXrowjR46gR48e6NmzZ5Hjg4rj5OQEExMTpKen65Snp6eX6Pgde3t7VKlSBadOnSq2joWFBezs7HReRERE9OLSOwH65ptv8Oeff+K3337D8ePH8euvv+LXX3/FiRMn8Msvv2Dr1q345ptv9F6wubk56tevj+joaKUsPz8f0dHRCAoKMqwXD3Hjxg0kJyfD3d29xNqkF0NeviA2+QrWJ15AbPIV5OU/8U3RiYjoOaH3GKAlS5bgyy+/RMeOHQtNe+WVVzBt2jR88803GD58uN4LDwsLQ9++fdGgQQM0atQIM2fOxM2bN5Wrwvr06YPy5ctj8uTJAO4NnD569Kjy/wsXLiAxMRE2NjaoXLkyAOCjjz5Cp06d4OXlhYsXLyIiIgImJibo1auX3nHRiy/qcCombDiK1KzbSpm7VoOITtURWpPJMhHRi07vZ4FZWlrixIkTxV5NdfbsWVSrVg3//fefQQHMnj0bX375JdLS0hAQEIBZs2YhMDAQANCqVSt4e3tj6dKlAIAzZ87Ax8enUBstW7ZETEwMAKBnz57YuXMnrly5AmdnZzRr1gxffPGFQTdp5LPAXmxRh1MxeEU8HtzxVf//37m96zEJIiJ6Dhny+613AuTo6IiYmBjUrl27yOmHDh1CixYtcO3aNcMjfsYwAXpx5eULmk3dpnPk534qAG5aDf4e1RomalWRdYiI6NlUKg9DDQoKwty5c4udPmfOnBIdu0NUGuJSrhab/ACAAEjNuo24FD7XjojoRab3GKAxY8agVatWuHLlCj766CNUq1YNIoJjx45hxowZWL9+PbZv316asRI9sYzrxSc/j1OPiIieT3onQE2aNEFkZCTeeecdrF27Vmeag4MDfvzxRzRt2rTEAyQqSS62mhKtR0REzyeDnhL66quvIiQkBJs3b8bJkycBAFWqVEHbtm1hZWVVKgESlaRGPo5w12qQlnW70CBo4P/GADXycXzaoRER0VNk8GPSrays8OqrrxY57cKFCyhfvvwTB0VUWkzUKkR0qo7BK+KhAnSSoIIhzxGdqnMANBHRC87gR2EUJS0tDcOGDYOfn19JNEdUqkJrumNu73pw0+qe5nLTangJPBGRkdD7CNC1a9cwZMgQbN26Febm5hg9ejSGDh2K8ePHY/r06ahduzaWLFlSmrESlZjQmu54ubob4lKuIuP6bbjY3jvtxSM/RETGQe8EaPTo0di9ezf69euHzZs348MPP0RUVBTUajW2bduGxo0bl2acRCXORK1CkG+5sg6DiIjKgN6nwP744w8sWbIE06dPx4YNGyAiCAgIwMaNG5n8EBER0XNF7wTo4sWL8Pf3BwB4e3tDo9Ggd+/epRYYERERUWnROwESEZia/t8ZMxMTE1haWpZKUERERESlSe8xQCKCNm3aKEnQf//9h06dOsHc3FynXnx8fMlGSERERFTC9E6AIiIidN537ty5xIMhIiIiehr0fhq8MeHT4ImIiJ4/pfI0eCIiIqIXBRMgIiIiMjoGPwuMiIiKl5cvvMM40XOACRARUQmJOpyKCRuOIjXrtlLmrtUgolN1PmOO6BnzRKfA/v33X+Tn55dULEREz62ow6kYvCJeJ/kBgLSs2xi8Ih5Rh1PLKDIiKsoTJUDVq1fHmTNnSigUIqLnU16+YMKGoyjqktqCsgkbjiIvnxfdEj0rnigB4hX0RERAXMrVQkd+7icAUrNuIy7l6tMLiogeileBERE9oYzrxSc/j1OPiErfEyVAn3zyCRwdHUsqFiKi55KLraZE6xFR6Xuiq8DCw8NLKg4ioudWIx9HuGs1SMu6XeQ4IBUAN+29S+KJ6NnAU2BERE/IRK1CRKfqAO4lO/creB/RqTrvB0T0DGECRERUAkJrumNu73pw0+qe5nLTajC3dz3eB4joGcMbIRIRlZDQmu54ubob7wRN9BxgAkREVIJM1CoE+ZYr6zCI6BEMPgUWFRWFv//+W3k/Z84cBAQE4I033sC1a9dKNDgiIiKi0mBwAjRy5EhkZ2cDAA4dOoQRI0agffv2SElJQVhYWIkHSERERFTSDD4FlpKSgurV713tsHbtWnTs2BGTJk1CfHw82rdvX+IBEhEREZU0g48AmZub49atWwCAP//8E23btgUAODo6KkeGiIiIiJ5lBh8BatasGcLCwtC0aVPExcUhMjISAPDPP/+gQoUKJR4gERERUUkz+AjQ7NmzYWpqip9//hlz585F+fLlAQB//PEHQkNDSzxAIiIiopKmEj7SvZDs7GxotVpkZWXBzs6urMMhIiIiPRjy+63XKbDs7GyloUeN82HCQERERM86vRIgBwcHpKamwsXFBfb29lCpCt/VVESgUqmQl5dX4kESERERlSS9EqBt27bB0dFR+X9RCRARERHR84JjgIrAMUBERETPH0N+vw2+Cmz8+PHIz88vVJ6VlYVevXoZ2hwREREZibx8QWzyFaxPvIDY5CvIyy+7YzAG3wdo0aJF2LJlC1asWIFKlSoBAGJiYtCnTx+4ubmVeIBERET0/Is6nIoJG44iNeu2Uuau1SCiU3WE1nR/6vEYfAQoKSkJFSpUQEBAABYsWICRI0eibdu2eOutt7B79+7SiJGIiIieY1GHUzF4RbxO8gMAaVm3MXhFPKIOpz71mAw+AuTg4IA1a9bgk08+wbvvvgtTU1P88ccfaNOmTWnER0RERM+xvHzBhA1HUdTJLgGgAjBhw1G8XN0NJuqnd5GVwUeAAODbb7/FN998g169eqFSpUp4//33cfDgwZKOjYiIiJ5zcSlXCx35uZ8ASM26jbiUq08vKDxGAhQaGooJEyZg2bJlWLlyJRISEtCiRQs0btwY06ZNK40YiYiI6DmVcb345Odx6pUUgxOgvLw8JCUloVu3bgAAS0tLzJ07Fz///DO+/vprgwOYM2cOvL29odFoEBgYiLi4uGLrHjlyBK+99hq8vb2hUqkwc+bMJ26TiIiISo+LraZE65UUgxOgrVu3wsPDo1B5hw4dcOjQIYPaioyMRFhYGCIiIhAfH486deogJCQEGRkZRda/desWKlWqhClTphR7xZmhbRIREVHpaeTjCHetBsWN7lHh3tVgjXwcn2ZYZXsjxMDAQDRs2BCzZ88GAOTn58PT0xPDhg3D6NGjHzqvt7c3hg8fjuHDh5dYmwV4I0QiIqKSU3AVGACdwdAFSdHc3vVK5FL4Ur0RYl5eHqZPn45GjRrBzc0Njo6OOi995ebm4sCBAwgODv6/YNRqBAcHIzY21tCwSq1NIiIiejKhNd0xt3c9uGl1T3O5aTUllvwYyuDL4CdMmICFCxdixIgR+PTTTzFmzBicOXMGv/76K8aNG6d3O5cvX0ZeXh5cXV11yl1dXXH8+HFDw3qiNnNycpCTk6O8f9QT74mIiMgwoTXd8XJ1N8SlXEXG9dtwsb132utpXvp+P4OPAK1cuRILFizAiBEjYGpqil69emHhwoUYN24c9uzZUxoxlrrJkydDq9UqL09Pz7IOiYiI6IVjolYhyLccOgeUR5BvuTJLfoDHSIDS0tJQq1YtAICNjQ2ysrIAAB07dsSmTZv0bsfJyQkmJiZIT0/XKU9PT3/sR2o8bpvh4eHIyspSXufPn3+s5RMREdHzweAEqEKFCkhNvXfLal9fX2zZsgUAsG/fPlhYWOjdjrm5OerXr4/o6GilLD8/H9HR0QgKCjI0rCdq08LCAnZ2djovIiIienEZPAbo1VdfRXR0NAIDAzFs2DD07t0bixYtwrlz5/Dhhx8a1FZYWBj69u2LBg0aoFGjRpg5cyZu3ryJ/v37AwD69OmD8uXLY/LkyQDuDXI+evSo8v8LFy4gMTERNjY2qFy5sl5tEhERET3xZfCxsbGIjY2Fn58fOnXqZPD8s2fPxpdffom0tDQEBARg1qxZCAwMBAC0atUK3t7eWLp0KQDgzJkz8PHxKdRGy5YtERMTo1eb+uBl8ERERM8fQ36/y/Q+QM8qJkBERETPn1K9D9D97OzscPr06SdpgoiIiOip0zsBunjxYqEyHjwiIiKi55HeCVCNGjWwatWq0oyFiIiI6KnQOwH64osv8O6776J79+64evUqAKB3794cI0NERETPHb0ToCFDhiApKQlXrlxB9erVsWHDBsydOxdOTk6lGR8RERFRiTPoPkA+Pj7Ytm0bZs+eja5du8Lf3x+mprpNxMfHl2iARERERCXN4Bshnj17FuvWrYODgwM6d+5cKAEiIiIietYZlL0UPAQ1ODgYR44cgbOzc2nFRURERFRq9E6AQkNDERcXh9mzZ6NPnz6lGRMRERFRqdI7AcrLy0NSUhIqVKhQmvEQERERlTq9E6CtW7eWZhxERERET80TPQqDiIiI6HnEBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6z0QCNGfOHHh7e0Oj0SAwMBBxcXEPrf/TTz+hWrVq0Gg0qFWrFn7//Xed6f369YNKpdJ5hYaGlmYXiIiI6DlS5glQZGQkwsLCEBERgfj4eNSpUwchISHIyMgosv7u3bvRq1cvDBgwAAkJCejSpQu6dOmCw4cP69QLDQ1Famqq8vrxxx+fRneI6DHl5Qtik69gfeIFxCZfQV6+lHVIRPQCU4lImX7LBAYGomHDhpg9ezYAID8/H56enhg2bBhGjx5dqH6PHj1w8+ZNbNy4USlr3LgxAgICMG/ePAD3jgBlZmbi119/fayYsrOzodVqkZWVBTs7u8dqg4j0F3U4FRM2HEVq1m2lzF2rQUSn6git6V6GkRHR88SQ3+8yPQKUm5uLAwcOIDg4WClTq9UIDg5GbGxskfPExsbq1AeAkJCQQvVjYmLg4uKCqlWrYvDgwbhy5UqxceTk5CA7O1vnRURPR9ThVAxeEa+T/ABAWtZtDF4Rj6jDqWUUGRG9yMo0Abp8+TLy8vLg6uqqU+7q6oq0tLQi50lLS3tk/dDQUPzwww+Ijo7G1KlTsWPHDrRr1w55eXlFtjl58mRotVrl5enp+YQ9IyJ95OULJmw4iqIOQxeUTdhwlKfDiKjEmZZ1AKWhZ8+eyv9r1aqF2rVrw9fXFzExMWjTpk2h+uHh4QgLC1PeZ2dnMwkiegriUq4WOvJzPwGQmnUbcSlXEeRb7ukFRkQvvDI9AuTk5AQTExOkp6frlKenp8PNza3Iedzc3AyqDwCVKlWCk5MTTp06VeR0CwsL2NnZ6byIqPRlXC8++XmcekRE+irTBMjc3Bz169dHdHS0Upafn4/o6GgEBQUVOU9QUJBOfQDYunVrsfUB4N9//8WVK1fg7s7BlETPEhdbTYnWIyLSV5lfBh8WFoYFCxZg2bJlOHbsGAYPHoybN2+if//+AIA+ffogPDxcqf/BBx8gKioKM2bMwPHjxzF+/Hjs378fQ4cOBQDcuHEDI0eOxJ49e3DmzBlER0ejc+fOqFy5MkJCQsqkj0RUtEY+jnDXaqAqZroK964Ga+Tj+DTDIiIjUOZjgHr06IFLly5h3LhxSEtLQ0BAAKKiopSBzufOnYNa/X95WpMmTbBq1Sp8+umn+OSTT+Dn54dff/0VNWvWBACYmJggKSkJy5YtQ2ZmJjw8PNC2bVtMnDgRFhYWZdJHIiqaiVqFiE7VMXhFPFSAzmDogqQoolN1mKiLS5GIiB5Pmd8H6FnE+wARPV28DxARlQRDfr/L/AgQEVFoTXe8XN0NcSlXkXH9Nlxs75324pEfIiotTICI6JlgolbxUnciemrKfBA0ERER0dPGBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOkyAiIiIyOgwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjoMAEiIiIio8MEiIiIiIwOEyAiIiIyOqZlHQA9f/LyBXEpV5Fx/TZcbDVo5OMIE7WqrMMyWtweVBpelP3qRekHlbxnIgGaM2cOvvzyS6SlpaFOnTr49ttv0ahRo2Lr//TTTxg7dizOnDkDPz8/TJ06Fe3bt1emiwgiIiKwYMECZGZmomnTppg7dy78/PyeRndeaFGHUzFhw1GkZt1Wyty1GkR0qo7Qmu5lGJlx4vag0vCi7FcvSj+odJT5KbDIyEiEhYUhIiIC8fHxqFOnDkJCQpCRkVFk/d27d6NXr14YMGAAEhIS0KVLF3Tp0gWHDx9W6kybNg2zZs3CvHnzsHfvXlhbWyMkJAS3b98usk3ST9ThVAxeEa/zZQIAaVm3MXhFPKIOp5ZRZMaJ24NKw4uyX70o/aDSoxIRKcsAAgMD0bBhQ8yePRsAkJ+fD09PTwwbNgyjR48uVL9Hjx64efMmNm7cqJQ1btwYAQEBmDdvHkQEHh4eGDFiBD766CMAQFZWFlxdXbF06VL07NnzkTFlZ2dDq9UiKysLdnZ2JdTT51tevqDZ1G2FvkwKqAC4aTX4e1RrHl5+Crg9qDS8KPvVi9IPMpwhv99legQoNzcXBw4cQHBwsFKmVqsRHByM2NjYIueJjY3VqQ8AISEhSv2UlBSkpaXp1NFqtQgMDCy2zZycHGRnZ+u8SFdcytViv0wAQACkZt1GXMrVpxeUEeP2oNLwouxXL0o/qHSVaQJ0+fJl5OXlwdXVVafc1dUVaWlpRc6Tlpb20PoF/xrS5uTJk6HVapWXp6fnY/XnRZZxXb/Th/rWoyfD7UGl4UXZr16UflDpKvMxQM+C8PBwZGVlKa/z58+XdUjPHBdbTYnWoyfD7UGl4UXZr16UflDpKtMEyMnJCSYmJkhPT9cpT09Ph5ubW5HzuLm5PbR+wb+GtGlhYQE7OzudF+lq5OMId60GxZ0tV+He1RWNfByfZlhGi9uDSsOLsl+9KP2g0lWmCZC5uTnq16+P6OhopSw/Px/R0dEICgoqcp6goCCd+gCwdetWpb6Pjw/c3Nx06mRnZ2Pv3r3FtkmPZqJWIaJTdQAo9KVS8D6iU3UOKHxKuD2oNLwo+9WL0g8qXWV+CiwsLAwLFizAsmXLcOzYMQwePBg3b95E//79AQB9+vRBeHi4Uv+DDz5AVFQUZsyYgePHj2P8+PHYv38/hg4dCgBQqVQYPnw4Pv/8c/z22284dOgQ+vTpAw8PD3Tp0qUsuvjCCK3pjrm968FNq3vY2E2rwdze9XhfjaeM24NKw4uyX70o/aDSU+aXwQPA7NmzlRshBgQEYNasWQgMDAQAtGrVCt7e3li6dKlS/6effsKnn36q3Ahx2rRpRd4Icf78+cjMzESzZs3w3XffoUqVKnrFw8vgH453Vn22cHtQaXhR9qsXpR+kH0N+v5+JBOhZwwSIiIjo+fPc3AeIiIiIqCwwASIiIiKjwwSIiIiIjA4TICIiIjI6TICIiIjI6DABIiIiIqPDBIiIiIiMDhMgIiIiMjpMgIiIiMjomJZ1AM+igptjZ2dnl3EkREREpK+C3219HnLBBKgI169fBwB4enqWcSRERERkqOvXr0Or1T60Dp8FVoT8/HxcvHgRtra2UKlK9qF52dnZ8PT0xPnz55/r54yxH88W9uPZwn48W9iPZ0tp9kNEcP36dXh4eECtfvgoHx4BKoJarUaFChVKdRl2dnbP9Q5cgP14trAfzxb249nCfjxbSqsfjzryU4CDoImIiMjoMAEiIiIio8ME6CmzsLBAREQELCwsyjqUJ8J+PFvYj2cL+/FsYT+eLc9KPzgImoiIiIwOjwARERGR0WECREREREaHCRAREREZHSZAj6FVq1YYPnz4E7WhUqnw66+/lkg8ZenMmTNQqVRITEzUe56lS5fC3t6+1GKiF09JfOZKw4vyOS4N/Jzrx9vbGzNnzizrMJ66mJgYqFQqZGZm6j3P+PHjERAQUGIxMAF6Qunp6ejXrx88PDxgZWWF0NBQnDx50uB2vL29oVKpdF5TpkxRpsfExKBz585wd3eHtbU1AgICsHLlSr3bnzx5Mho2bAhbW1u4uLigS5cuOHHihE6d5ORkvPrqq3B2doadnR1ef/11pKenG9yXffv2oU2bNrC3t4eDgwNCQkJw8OBBg9t53H48SkHS9uBrz549OvV++uknVKtWDRqNBrVq1cLvv/+uM33dunVo27YtypUrZ3ASmJeXh7Fjx8LHxweWlpbw9fXFxIkTdZ5fM378eFSrVg3W1tZwcHBAcHAw9u7dq0wv+AIp6rVv3z6lXlJSEpo3bw6NRgNPT09MmzatUDwzZ85E1apVYWlpCU9PT3z44Ye4ffu23v2ZM2cOvL29odFoEBgYiLi4OADA1atXMWzYMKXtihUr4v3330dWVpbebZeFKVOmQKVSPVbStWnTJgQGBsLS0hIODg7o0qWLMu3KlSsIDQ2Fh4cHLCws4OnpiaFDh+o8d7Bfv35FbtMaNWrotfzr169j+PDh8PLygqWlJZo0aaKzPwDAsWPH8Morr0Cr1cLa2hoNGzbEuXPnlOn6fBe88sorqFixIjQaDdzd3fHWW2/h4sWLBq+vJ+nHw4wfP77I9Whtba3UWbp0aaHpGo2mxPoAABcuXEDv3r1Rrlw5WFpaolatWti/f7/B7cTGxqJ169awtraGnZ0dWrRogf/++w+Aft8Ft2/fRr9+/VCrVi2Ymprq7JePUtS6rFatWqF6IoJ27do99h8GmzdvRuPGjWFrawtnZ2e89tprOHPmjMHt6IsJ0BMQEXTp0gWnT5/G+vXrkZCQAC8vLwQHB+PmzZsGt/fZZ58hNTVVeQ0bNkyZtnv3btSuXRtr165FUlIS+vfvjz59+mDjxo16tb1jxw6899572LNnD7Zu3Yo7d+6gbdu2Spw3b95E27ZtoVKpsG3bNuzatQu5ubno1KkT8vPz9e7DjRs3EBoaiooVK2Lv3r34+++/YWtri5CQENy5c8ewFfIY/TDEn3/+qbO+69evr0zbvXs3evXqhQEDBiAhIQFdunRBly5dcPjwYaXOzZs30axZM0ydOtXgZU+dOhVz587F7NmzcezYMUydOhXTpk3Dt99+q9SpUqUKZs+ejUOHDuHvv/+Gt7c32rZti0uXLgEAmjRpohN/amoqBg4cCB8fHzRo0ADAvVvOt23bFl5eXjhw4AC+/PJLjB8/HvPnz1eWs2rVKowePRoRERE4duwYFi1ahMjISHzyySd69SUyMhJhYWGIiIhAfHw86tSpg5CQEGRkZODixYu4ePEipk+fjsOHD2Pp0qWIiorCgAEDDF5nT8u+ffvw/fffo3bt2gbPu3btWrz11lvo378/Dh48iF27duGNN95QpqvVanTu3Bm//fYb/vnnHyxduhR//vknBg0apNT55ptvdLbp+fPn4ejoiO7du+sVw8CBA7F161YsX74chw4dQtu2bREcHIwLFy4AuJfcNGvWDNWqVUNMTAySkpIwduxY5Ydf3++Cl156CWvWrMGJEyewdu1aJCcno1u3bgavs8ftx6N89NFHhT4f1atXL7Qe7ezsdOqcPXu2xPpw7do1NG3aFGZmZvjjjz9w9OhRzJgxAw4ODga1Exsbi9DQULRt2xZxcXHYt28fhg4dqjzqQZ/vgry8PFhaWuL9999HcHCwwX2pUaOGTvt///13oTozZ8587MdHpaSkoHPnzmjdujUSExOxefNmXL58GV27dn2s9vQi9FA3btyQt956S6ytrcXNzU2mT58uLVu2lA8++EBOnDghAOTw4cNK/by8PHF2dpYFCxYoZf/88480b95cLCwsxN/fX7Zs2SIA5JdfflHqeHl5yddff21QbO3bt5f+/fs/Vr8yMjIEgOzYsUNERDZv3ixqtVqysrKUOpmZmaJSqWTr1q1K2d69eyUgIEAsLCykfv36sm7dOgEgCQkJIiKyb98+ASDnzp1T5klKShIAcvLkSRERWbJkiWi1Wvnll1+kcuXKYmFhIW3bttWZ53H7ISIyY8YMqVmzplhZWUmFChVk8ODBcv36dWV6SkqKTsxFef3116VDhw46ZYGBgfLuu+8WqqtPew/q0KGD/O9//9Mp69q1q7z55pvFzpOVlSUA5M8//yxyem5urjg7O8tnn32mlH333Xfi4OAgOTk5StmoUaOkatWqyvv33ntPWrdurdNWWFiYNG3aVK++NGrUSN577z3lfV5ennh4eMjkyZOLrL9mzRoxNzeXO3fuKGWHDh2S0NBQsba2FhcXF+ndu7dcunRJmd6yZUt577335L333hM7OzspV66cfPrpp5Kfn6/UuX37towYMUI8PDzEyspKGjVqJNu3b9erDwWuX78ufn5+snXrVuVzXuBRn+M7d+5I+fLlZeHChQYt85tvvpEKFSoUO/2XX34RlUolZ86ceWRbt27dEhMTE9m4caNOeb169WTMmDEiItKjRw/p3bt3sW3o+13woPXr14tKpZLc3FwRebLPuT79MHR7JyYmCgDZuXOnUlYQ48P88MMPUr9+fbGxsRFXV1fp1auXpKenP7IPIvc+a82aNXtoHS8vL/nss8+kZ8+eYmVlJR4eHjJ79mydOoGBgfLpp5/qtUyRor8L7te3b1/p3Lmz3u1FRERInTp1HlonISFBypcvL6mpqYV+30RENm3aJH5+fqLRaKRVq1ayZMkSASDXrl0TEZGffvpJTE1NJS8vT5nnt99+09mnCuKYN2+eVKhQQSwtLaV79+6SmZmpd1/uxyNAjzBy5Ejs2LED69evx5YtWxATE4P4+HgAQE5ODgDoHDJVq9WwsLBQsuP8/Hx07doV5ubm2Lt3L+bNm4dRo0YVuawpU6agXLlyqFu3Lr788kvcvXv3obFlZWXB0dHxsfpVcAqiYP6cnByoVCqdG1NpNBqo1WqlLzdu3EDHjh1RvXp1HDhwAOPHj8dHH32k027VqlVRrlw5LFq0CLm5ufjvv/+waNEi+Pv7w9vbW6l369YtfPHFF/jhhx+wa9cuZGZmomfPnk/cD+DeNpg1axaOHDmCZcuWYdu2bfj4448LzfvKK6/AxcUFzZo1w2+//aYzLTY2ttBfSSEhIYiNjTU4xqI0adIE0dHR+OeffwAABw8exN9//4127doVWT83Nxfz58+HVqtFnTp1iqzz22+/4cqVK+jfv79OP1q0aAFzc3Odfpw4cQLXrl1TYjlw4IBy2ur06dP4/fff0b59+0f2Izc3FwcOHNBZV2q1GsHBwcWuq6ysLNjZ2cHU9N6jCDMzM9G6dWvUrVsX+/fvR1RUFNLT0/H666/rzLds2TKYmpoiLi4O33zzDb766issXLhQmT506FDExsZi9erVSEpKQvfu3Q0+Jf3ee++hQ4cOhba9Pp/j+Ph4XLhwAWq1GnXr1oW7uzvatWunc9TwQRcvXsS6devQsmXLYussWrQIwcHB8PLyemT8d+/eRV5eXqHTOJaWlvj777+Rn5+PTZs2oUqVKggJCYGLiwsCAwN1Tlfo813woKtXr2LlypVo0qQJzMzMlPLH/Zw/qh+A4dt74cKFqFKlCpo3b65TfuPGDXh5ecHT0xOdO3fGkSNHdKbfuXMHEydOxMGDB/Hrr7/izJkz6Nev3yP7ANz7TDZo0ADdu3eHi4sL6tatiwULFhSq9+WXX6JOnTpISEjA6NGj8cEHH2Dr1q0AgIyMDOzduxcuLi5o0qQJXF1d0bJly2K3RcFyH/wueFInT56Eh4cHKlWqhDfffFPnlOmtW7fwxhtvYM6cOXBzcys07/nz59G1a1d06tQJiYmJGDhwIEaPHq1Tp379+lCr1ViyZAny8vKQlZWF5cuXIzg4WGefOnXqFNasWYMNGzYgKioKCQkJGDJkyON16rHSJiNx/fp1MTc3lzVr1ihlV65cEUtLS/nggw8kNzdXKlasKN27d5erV69KTk6OTJkyRQBI27ZtReTeX1OmpqZy4cIFpY0//vijUIY8Y8YM2b59uxw8eFDmzp0r9vb28uGHHxYbW2RkpJibm+scfdJXXl6edOjQQecv/IyMDLGzs5MPPvhAbt68KTdu3JChQ4cKAHnnnXdEROT777+XcuXKyX///afMN3fu3EJHPw4dOiS+vr6iVqtFrVZL1apVdf56Lcj89+zZo5QdO3ZMAMjevXufqB9F+emnn6RcuXLK+0uXLsmMGTNkz549EhcXJ6NGjRKVSiXr169X6piZmcmqVat02pkzZ464uLgUav9xjgDl5eUpyzU1NRWVSiWTJk0qVG/Dhg1ibW0tKpVKPDw8JC4urtg227VrJ+3atdMpe/nll5XtV+DIkSMCQI4ePaqUffPNN2JmZiampqYCQAYNGqRXPy5cuCAAZPfu3TrlI0eOlEaNGhWqf+nSJalYsaJ88sknStnEiROVz0uB8+fPCwA5ceKEiNw7AuTv769zxGfUqFHi7+8vIiJnz54VExMTnc+ZiEibNm0kPDxcr778+OOPUrNmTWX/vv8IkD6f4x9//FEASMWKFeXnn3+W/fv3S69evaRcuXJy5coVnWX17NlTLC0tBYB06tRJ5zN1vwsXLoiJiYlERkbq1QcRkaCgIGnZsqVcuHBB7t69K8uXLxe1Wi1VqlRR/jq3srKSr776ShISEmTy5MmiUqkkJiZGRPT7Lijw8ccfi5WVlQCQxo0by+XLl5VpT/o5f1g/DN3e//33nzg4OMjUqVN1ynfv3i3Lli2ThIQEiYmJkY4dO4qdnZ2cP3++2LgKjnLff1S5OBYWFmJhYSHh4eESHx8v33//vWg0Glm6dKlSx8vLS0JDQ3Xm69Gjh/JZjo2NFQDi6Ogoixcvlvj4eBk+fLiYm5vLP//8U+Ryi/ouuJ+hR4B+//13WbNmjRw8eFCioqIkKChIKlasKNnZ2SIi8s4778iAAQOU+g/+voWHh0v16tV12hw1apTOESARkZiYGHFxcRETExMBIEFBQTrTIyIixMTERP7991+l7I8//hC1Wi2pqal690eJ0+A5jEjBIdOzZ8/qlAcEBChfjPv375c6deoIADExMZGQkBBp166dskPPnDlTfHx8dObPzMws8hDh/RYtWiSmpqZy+/btQtO2bdsmVlZWsmzZssfq16BBg8TLy6vQh3zz5s1SqVIlUalUYmJiIr1795Z69eopP4bDhw+Xl156SWeegnVU8ON/69YtadSokfTp00fi4uIkNjZWXnvtNalRo4bcunVLRO59MT54qFNExN7eXueL4XH7sXXrVmndurV4eHiIjY2NaDQaASA3b94stq233npL51B1aSdAP/74o1SoUEF+/PFHSUpKkh9++EEcHR0L9f/GjRty8uRJiY2Nlf/973/i7e1d5OH38+fPi1qtlp9//lmnXJ8EaPv27eLq6ioLFiyQpKQkWbdunXh6ehZ7+Px+hiRAWVlZ0qhRIwkNDVUOaYuIdOvWTczMzMTa2lrnBUB+//13EbmXjDx4uvfXX38VU1NTuXv3rmzcuFEAFGrD1NRUXn/99Uf249y5c+Li4iIHDx5Uyu5PgPT5HK9cuVIAyPfff6/UuX37tjg5Ocm8efN05k1NTZVjx47J+vXrpXr16jJ48OAi45o0aZKUK1dO5xTmo5w6dUpatGihfCc1bNhQ3nzzTalWrZqyvXr16qUzT6dOnaRnz57K+0d9FxS4dOmSnDhxQrZs2SJNmzaV9u3bK0nqk37OH9YPQ7f3qlWrxNTUVNLS0h66zNzcXPH19dU53bR//37p2LGjeHp6io2NjZLwHTly5JF9MDMzk6CgIJ2yYcOGSePGjZX3Xl5eMmHCBJ06M2fOFG9vbxER2bVrlwAolNjVqlVLRo8eXWiZxX0X3M/QBOhB165dEzs7O1m4cKGsX79eKleurJMQPvj71qVLlyI/v/cnQKmpqeLn5ycjR46U+Ph42bFjh7Rs2VLatGmj7FMRERHFfg4LEnhDmD7ecSMqUL9+fSQmJiIrKwu5ublwdnZGYGCgMvDscQUGBuLu3bs4c+YMqlatqpTv2LEDnTp1wtdff40+ffoY3O7QoUOxceNG7Ny5ExUqVNCZ1rZtWyQnJ+Py5cswNTWFvb093NzcUKlSJb3bX7VqFc6cOYPY2FhlgN6qVavg4OCA9evXP9ZpLkP6cebMGXTs2BGDBw/GF198AUdHR/z9998YMGAAcnNzYWVlVWR7gYGByiFnAHBzcyt01Ut6enqRh3cfx8iRIzF69GhlfdSqVQtnz57F5MmT0bdvX6WetbU1KleujMqVK6Nx48bw8/PDokWLEB4ertPekiVLUK5cObzyyis65cX1o2AaAIwdOxZvvfUWBg4cqMRy8+ZNvPPOOxgzZoyyHYvi5OQEExOTR66r69evIzQ0FLa2tvjll190DmnfuHEDnTp1KnIwubu7e7HLvt+NGzdgYmKCAwcOwMTERGeajY3NI+c/cOAAMjIyUK9ePaUsLy8PO3fuxOzZszFjxoxHtlEQa/Xq1ZUyCwsLVKpUSed0AXBv3bu5uaFatWpwdHRE8+bNMXbsWJ3+iggWL16Mt956S+cU5qP4+vpix44duHnzJrKzs+Hu7o4ePXqgUqVKcHJygqmpqU6MAODv769zSkXf7wInJyc4OTmhSpUq8Pf3h6enJ/bs2YOgoCC9432cfhi6vRcuXIiOHTvC1dX1ocs0MzND3bp1cerUKQD3BoSHhIQgJCQEK1euhLOzM86dO4eQkBDk5uY+sg/u7u5Fruu1a9c+ct772wBQZDsP7ldA8d8FJcne3h5VqlTBqVOncOjQISQnJxe65cFrr72G5s2bIyYmRq8258yZA61Wq3OV6ooVK+Dp6Ym9e/eicePGJdiDezgG6CF8fX1hZmamc+nxtWvXlHEb99NqtXB2dsbJkyexf/9+dO7cGcC9nfT8+fNITU1V6j54uXVREhMToVar4eLiopTFxMSgQ4cOmDp1Kt555x2D+iIiGDp0KH755Rds27YNPj4+xdZ1cnKCvb09tm3bhoyMDOWD5O/vj6SkJJ3Lox/sy61bt6BWq3WuBCh4f/8VJHfv3tW5FPTEiRPIzMyEv7//E/XjwIEDyM/Px4wZM9C4cWNUqVJFr0tzExMTdX58goKCEB0drVNn69atJfLFDvzferqfiYnJI6+4y8/PV8aeFRARLFmyBH369NFJLIB7/di5c6fOFXhbt25F1apVlStRiouloO2HMTc3R/369XXWVX5+PqKjo5V1VXAlmrm5OX777bdC4zrq1auHI0eOwNvbW0n2Cl73X7J8/+cQuLfv+fn5wcTEBHXr1kVeXh4yMjIKtaFP0tqmTRscOnQIiYmJyqtBgwZ48803kZiYqNfnuH79+rCwsNC5LcOdO3dw5syZh47fKdjmD27XHTt24NSpU499xZy1tTXc3d1x7do1bN68GZ07d4a5uTkaNmxY6NYR//zzT5ExFvddoG8/Hvdz/qh+GLK9U1JSsH37dr3WY15eHg4dOqR8Fxw/fhxXrlzBlClT0Lx5c1SrVg0ZGRl6x960aVO91vWD+9KePXuUdeTt7Q0PDw+92nnYd0FJunHjBpKTk+Hu7o7Ro0cjKSlJ57MDAF9//TWWLFkC4N5vR8EYwwLF/Xbcr+B76P7vxXPnzul8p+/ZswdqtVrnQIHeDD5mZGQKTrNER0fLoUOH5JVXXhEbGxvl0PiaNWtk+/btkpycLL/++qt4eXlJ165dlfnz8vKkevXq8vLLL0tiYqLs3LlT6tevr3OIcPfu3fL1119LYmKiJCcny4oVK8TZ2Vn69OmjtFNw2is8PFxSU1OV14NjC4ozePBg0Wq1EhMTozN/wWkpEZHFixdLbGysnDp1SpYvXy6Ojo4SFhamTL9+/bo4OTlJ79695ciRI7Jp0yapXLmyzumfY8eOiYWFhQwePFiOHj0qhw8flt69e4tWq5WLFy+KyL1D42ZmZtKoUSPZs2eP7N+/Xxo3bqxzWPhx+1FwSm7mzJmSnJwsP/zwg5QvX17nUOvSpUtl1apVcuzYMTl27Jh88cUXolarZfHixcpydu3aJaampjJ9+nQ5duyYREREiJmZmRw6dEipc+XKFUlISJBNmzYJAFm9erUkJCTodS66b9++Ur58edm4caOkpKTIunXrxMnJST7++GMRuXfqKzw8XGJjY+XMmTOyf/9+6d+/v1hYWBQa9/Xnn38KADl27Fih5WRmZoqrq6u89dZbcvjwYVm9erVYWVnpnKaJiIgQW1tb+fHHH+X06dOyZcsW8fX11evUkYjI6tWrxcLCQpYuXSpHjx6Vd955R+zt7SUtLU2ysrIkMDBQatWqJadOndLZZnfv3hWRe6fRnJ2dpVu3bhIXFyenTp2SqKgo6devn1KnZcuWYmNjIx9++KEcP35cVq1aJdbW1jqnlt58803x9vaWtWvXyunTp2Xv3r0yadKkQlcS6ev+U2D6fI5FRD744AMpX768bN68WY4fPy4DBgwQFxcXuXr1qojcuxJm8eLFcujQIUlJSZGNGzeKv79/kePYevfuLYGBgQbHHRUVJX/88YeyLevUqSOBgYHKacd169aJmZmZzJ8/X06ePCnffvutmJiYyF9//aW08ajvgj179si3334rCQkJcubMGYmOjpYmTZqIr6+vctr+ST7n+vRD3+396aefioeHh7Iv3W/ChAmyefNmSU5OlgMHDkjPnj1Fo9Eop7cyMjLE3NxcRo4cKcnJybJ+/XqpUqWK3qe84+LixNTUVL744gs5efKkrFy5UqysrGTFihVKHS8vL7Gzs5OpU6fKiRMnZPbs2WJiYiJRUVFKna+//lrs7Ozkp59+kpMnT8qnn34qGo1GTp06pbO8h30XiNw7/Z2QkCCdOnWSVq1aSUJCgl79GDFihMTExEhKSors2rVLgoODxcnJSTIyMoqs/+Dn4uzZs2Jubi4fffSRHD9+XFauXClubm4638vR0dGiUqlkwoQJ8s8//8iBAwckJCREvLy8lO/3iIgIsba2luDgYOVzWKVKFZ3Tt4ZgAvQI169fl969e4uVlZW4urrKtGnTdL4YCy5hNTMzk4oVK8qnn35a6Hz9iRMnpFmzZmJubi5VqlSRqKgonR3kwIEDEhgYKFqtVjQajfj7+8ukSZN0xv/07dtXABR6tWzZUq9+FDUvAFmyZIlSZ9SoUeLq6ipmZmbi5+cnM2bM0Bl0KnJvQF6dOnXE3NxcAgICZO3atYW+DArGA2i1WnFwcJDWrVtLbGysMr3g0tO1a9dKpUqVxMLCQoKDgwuNtXrcfnz11Vfi7u4ulpaWEhISIj/88EOhBMjf31+srKzEzs5OGjVqJD/99FOhZa1Zs0aqVKki5ubmUqNGDdm0aZPO9IJBng++IiIiHtmP7Oxs+eCDD6RixYqi0WikUqVKMmbMGGXf+e+//+TVV18VDw8PMTc3F3d3d3nllVeKHATdq1cvadKkSbHLOnjwoDRr1kwsLCykfPnyMmXKFJ3pd+7ckfHjx4uvr69oNBrx9PSUIUOG6Aw+fJRvv/1WKlasKObm5soPnsi98UXFbbOUlBRl/n/++UdeffVVsbe3F0tLS6lWrZoMHz5c2f9atmwpQ4YMkUGDBomdnZ04ODjIJ598orN/5ubmyrhx48Tb21vMzMzE3d1dXn31VUlKStK7H/d78DL4R32OC2IYMWKEuLi4iK2trQQHB+skrNu2bZOgoCDls+7n5yejRo0qtK4zMzPF0tJS5s+fb3DckZGRUqlSJTE3Nxc3Nzd57733Cl0mvGjRIqlcubJoNBqpU6eO/PrrrzrTH/VdkJSUJC+99JI4OjqKhYWFeHt7y6BBg3QGpz7J51yffuizvfPy8qRChQo6g+7vN3z4cGW/dXV1lfbt20t8fLxOnVWrVom3t7dYWFhIUFCQ/PbbbwaN+duwYYPUrFlTLCwspFq1aoW2acEYoO7du4uVlZW4ubnJN998U6idyZMnS4UKFcTKykqCgoJ0EtYCj/ou8PLyKvKz+Cg9evQQd3d3MTc3l/Lly0uPHj0KJV/3e/BzIXJvPRTcDqF58+ayePHiQoOgf/zxR6lbt65YW1uLs7OzvPLKKzrJXMFl8N999514eHiIRqORbt26KX9gGEr1/4MlIiIiMhocA0RERERGhwkQERERGR0mQERERGR0mAARERGR0WECREREREaHCRAREREZHSZAREREZHSYABEREZHRYQJEVEZiYmKgUqmQmZlZ1qE8M8aPH4+AgIBip+uzzpYuXVrowYxFWbRoEdq2bau879evH7p06aJ/sM8offv/ort8+TJcXFzw77//lnUo9IxiAkRGLS8vD02aNEHXrl11yrOysuDp6YkxY8aU2rKbNGmC1NRUaLXaUlvG+PHjoVKpoFKpYGJiAk9PT7zzzju4evVqqS2zNJXUOrt9+zbGjh2LiIiIEoqsMJVKhV9//fWR9by9vZVtVPCaMmVKqcVV1vRdL0/KyckJffr0KdVtTM83JkBk1ExMTLB06VJERUVh5cqVSvmwYcPg6OhYql+e5ubmcHNzg0qlKrVlAECNGjWQmpqKc+fOYcmSJYiKisLgwYNLdZmPcv/T6Q1RUuvs559/hp2dHZo2bfpE7ZSUzz77DKmpqcpr2LBhZR1SIY+7zUqLPvH0798fK1eufG4TfipdTIDI6FWpUgVTpkzBsGHDkJqaivXr12P16tX44YcfYG5uXux8o0aNQpUqVWBlZYVKlSph7NixypeyiCA4OBghISEoeNze1atXUaFCBYwbNw5A4dM5Z8+eRadOneDg4ABra2vUqFEDv//++xP3z9TUFG5ubihfvjyCg4PRvXt3bN26VafOwoUL4e/vD41Gg2rVquG7777Tmf7vv/+iV69ecHR0hLW1NRo0aIC9e/cq0+fOnQtfX1+Ym5ujatWqWL58uc78KpUKc+fOxSuvvAJra2t88cUXAIApU6bA1dUVtra2GDBgAG7fvv3QvhR1Cmzp0qWoWLEirKys8Oqrr+LKlSuPXCerV69Gp06dHlonKioKzZo1g729PcqVK4eOHTsiOTlZmZ6bm4uhQ4fC3d0dGo0GXl5emDx5MoB7R3UA4NVXX4VKpVLeF8fW1hZubm7Ky9ra+qH1MzMz8e6778LV1RUajQY1a9bExo0bdeps3rwZ/v7+sLGxQWhoKFJTU5Vp+/btw8svvwwnJydotVq0bNkS8fHxOvMXtc3y8vIwYMAA+Pj4wNLSElWrVsU333xTKL7FixejRo0asLCwgLu7O4YOHfrI9bJ+/XrUq1cPGo0GlSpVwoQJE3D37t2HxnPt2jW8+eabcHZ2hqWlJfz8/LBkyRJlnho1asDDwwO//PLLQ9cnGanHeoQq0QsmPz9fWrVqJW3atBEXFxeZOHHiI+eZOHGi7Nq1S1JSUuS3334TV1dXmTp1qjL933//FQcHB5k5c6aIiHTv3l0aNWokd+7cEZH/e1J6wdOQO3ToIC+//LIkJSVJcnKybNiwQXbs2PFE/Sp4enKBlJQUqVGjhri6uiplK1asEHd3d1m7dq2cPn1a1q5dK46OjrJ06VIREbl+/bpUqlRJmjdvLn/99ZecPHlSIiMjZffu3SIism7dOjEzM5M5c+bIiRMnZMaMGWJiYiLbtm1TlgFAXFxcZPHixZKcnCxnz56VyMhIsbCwkIULF8rx48dlzJgxYmtrqxPvgx5cZ3v27BG1Wi1Tp06VEydOyDfffCP29vai1Woful60Wq2sXr1ap6xv377SuXNn5f3PP/8sa9eulZMnT0pCQoJ06tRJatWqJXl5eSIi8uWXX4qnp6fs3LlTzpw5I3/99ZesWrVKREQyMjIEgCxZskRSU1MlIyOj2Fi8vLzE1dVVHB0dJSAgQKZNm6bsI0XJy8uTxo0bS40aNWTLli3KvvL777+LyL2nsJuZmUlwcLDs27dPDhw4IP7+/vLGG28obURHR8vy5cvl2LFjcvToURkwYIC4urpKdna2UqeobVbwBPZ9+/bJ6dOnZcWKFWJlZSWRkZHKfN99951oNBqZOXOmnDhxQuLi4uTrr79+6HrZuXOn2NnZydKlSyU5OVm2bNki3t7eMn78+IfG895770lAQIDs27dPUlJSZOvWrfLbb7/prK8ePXpI3759i12fZLyYABH9f8eOHRMAUqtWrYf+ABXnyy+/lPr16+uUrVmzRjQajYwePVqsra3ln3/+UaY9+GNeq1YtnS/8khARESFqtVqsra1Fo9EIAAEgX331lVLH19dX+eEuMHHiRAkKChIRke+//15sbW3lypUrRS6jSZMm8vbbb+uUde/eXdq3b6+8ByDDhw/XqRMUFCRDhgzRKQsMDDQoAerVq5fOckTu/eA9LAG6du2aAJCdO3fqlD+YAD3o0qVLAkAOHTokIiLDhg2T1q1bS35+fpH1Acgvv/xSbHsFZsyYIdu3b5eDBw/K3Llzxd7eXj788MNi62/evFnUarWcOHGiyOlLliwRAHLq1CmlbM6cOTpJ74Py8vLE1tZWNmzYoBP/g9usKO+995689tprynsPDw8ZM2ZMsfWLWi9t2rSRSZMm6ZQtX75c3N3dHxpPp06dpH///g+N78MPP5RWrVo9qhtkhHgKjOj/W7x4MaysrJCSkqJz5cigQYNgY2OjvApERkaiadOmcHNzg42NDT799FOcO3dOp83u3bvj1VdfxZQpUzB9+nT4+fkVu/z3338fn3/+OZo2bYqIiAgkJSUVW3fSpEk6MT243PtVrVoViYmJ2LdvH0aNGoWQkBBljMnNmzeRnJyMAQMG6LT3+eefK6d7EhMTUbduXTg6OhbZ/rFjxwqNpWnatCmOHTumU9agQYNC8wUGBuqUBQUFFduP4pZtaBv//fcfAECj0Ty03smTJ9GrVy9UqlQJdnZ2yumagnXdr18/JCYmomrVqnj//fexZcsWg2IvEBYWhlatWqF27doYNGgQZsyYgW+//RY5OTlF1k9MTESFChVQpUqVYtu0srKCr6+v8t7d3R0ZGRnK+/T0dLz99tvw8/ODVquFnZ0dbty4UWg/enCbAcCcOXNQv359ODs7w8bGBvPnz1fmy8jIwMWLF9GmTRuD1sHBgwfx2Wef6eyDb7/9NlJTU3Hr1q1i4xk8eDBWr16NgIAAfPzxx9i9e3ehti0tLXXaICrABIgIwO7du/H1119j48aNaNSoEQYMGKCM3fnss8+QmJiovAAgNjYWb775Jtq3b4+NGzciISEBY8aMQW5urk67t27dwoEDB2BiYoKTJ08+NIaBAwfi9OnTeOutt3Do0CE0aNAA3377bZF1Bw0apBOTh4dHse2am5ujcuXKqFmzJqZMmQITExNMmDABAHDjxg0AwIIFC3TaO3z4MPbs2QPg3g9ISXjUuJanpVy5clCpVLh27dpD63Xq1AlXr17FggULsHfvXmXMU8E2rlevHlJSUjBx4kT8999/eP3119GtW7cnji8wMBB3797FmTNnipyuz/YwMzPTea9SqZT9GQD69u2LxMREfPPNN9i9ezcSExNRrly5Qvvvg9ts9erV+OijjzBgwABs2bIFiYmJ6N+/vzLf4+4rN27cwIQJE3T2wUOHDuHkyZM6ieqD8bRr1w5nz57Fhx9+qCReH330kU6dq1evwtnZ+bHiohcbEyAyerdu3UK/fv0wePBgvPTSS1i0aBHi4uIwb948AICLiwsqV66svIB7CZOXlxfGjBmDBg0awM/PD2fPni3U9ogRI6BWq/HHH39g1qxZ2LZt20Nj8fT0xKBBg7Bu3TqMGDECCxYsKLKeo6OjTkympqZ69/fTTz/F9OnTcfHiRbi6usLDwwOnT5/Waa9y5crw8fEBANSuXRuJiYnFXknj7++PXbt26ZTt2rUL1atXf2gc/v7+OgOpAShJl74epw1zc3NUr14dR48eLbbOlStXcOLECXz66ado06YN/P39i0yY7Ozs0KNHDyxYsACRkZFYu3atsp7MzMyQl5dnUH+Ae0d41Go1XFxcipxeu3Zt/Pvvv/jnn38MbrvArl278P7776N9+/bKYOXLly/rNV+TJk0wZMgQ1K1bF5UrV9YZGG5rawtvb29ER0cX20ZR66VevXo4ceJEoX2wcuXKUKsf/jPl7OyMvn37YsWKFZg5cybmz5+vM/3w4cOoW7fuI/tGxkf/b02iF1R4eDhERLn3ire3N6ZPn46PPvoI7dq1K/IKHj8/P5w7dw6rV69Gw4YNsWnTpkJXmmzatAmLFy9GbGws6tWrh5EjR6Jv375ISkqCg4NDoTaHDx+Odu3aoUqVKrh27Rq2b98Of3//Eu9vUFAQateujUmTJmH27NmYMGEC3n//fWi1WoSGhiInJwf79+/HtWvXEBYWhl69emHSpEno0qULJk+eDHd3dyQkJMDDwwNBQUEYOXIkXn/9ddStWxfBwcHYsGED1q1bhz///POhcXzwwQfo168fGjRogKZNm2LlypU4cuQIKlWqpHdf3n//fTRt2hTTp09H586dsXnzZkRFRT1yvpCQEPz9998YPnx4kdMdHBxQrlw5zJ8/H+7u7jh37hxGjx6tU+err76Cu7s76tatC7VajZ9++glubm7KTQgLEoGmTZvCwsKiyG0eGxuLvXv34qWXXoKtrS1iY2Px4Ycfonfv3kXWB4CWLVuiRYsWeO211/DVV1+hcuXKOH78OFQqFUJDQx/Zd+De/rt8+XI0aNAA2dnZGDlypF5Hb/z8/PDDDz9g8+bN8PHxwfLly7Fv3z4lWQbu3Xtq0KBBcHFxQbt27XD9+nXs2rVLOe1a1HoZN24cOnbsiIoVK6Jbt25Qq9U4ePAgDh8+jM8//7zYeMaNG4f69eujRo0ayMnJwcaNG3U+MwVHYCdNmqTXeiEjU8ZjkIjKVExMjJiYmMhff/1VaFrbtm0fOsh15MiRUq5cObGxsZEePXrI119/rQy+zcjIEFdXV52Bnbm5uVK/fn15/fXXRaTwgN6hQ4eKr6+vWFhYiLOzs7z11lty+fLlJ+rfg1eBFfjxxx/FwsJCzp07JyIiK1eulICAADE3NxcHBwdp0aKFrFu3Tql/5swZee2118TOzk6srKykQYMGsnfvXmX6d999J5UqVRIzMzOpUqWK/PDDDzrLQzEDgr/44gtxcnISGxsb6du3r3z88ccGDYIWEVm0aJFUqFBBLC0tpVOnTjJ9+vRHXgV25MgRsbS0lMzMTKXswUHQW7duFX9/f7GwsJDatWtLTEyMTj/mz58vAQEBYm1tLXZ2dtKmTRuJj49X5v/tt9+kcuXKYmpqKl5eXkXGceDAAQkMDBStVisajUb8/f1l0qRJcvv27YfGf+XKFenfv7+UK1dONBqN1KxZUzZu3Cgi9wZBP9j/X375Re7/uo+Pj5cGDRqIRqMRPz8/+emnn8TLy0u5Wkuk6G12+/Zt6devn2i1WrG3t5fBgwfL6NGjC22zefPmSdWqVcXMzEzc3d1l2LBhj1wvUVFR0qRJE7G0tBQ7Oztp1KiRzJ8//6HxTJw4Ufz9/cXS0lIcHR2lc+fOcvr0aWX6qlWrpGrVqg9dl2S8VCL3nRgmIjIS3bt3R7169RAeHl7WoVApady4Md5//3288cYbZR0KPYM4BoiIjNKXX36pc1UfvVguX76Mrl27olevXmUdCj2jeASIiIiIjA6PABEREZHRYQJERERERocJEBERERkdJkBERERkdJgAERERkdFhAkRERERGhwkQERERGR0mQERERGR0mAARERGR0fl/3Azlwil3bKQAAAAASUVORK5CYII="
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "execution_count": 67
   },
   {
    "cell_type": "markdown",
@@ -1848,9 +3254,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:40.298031Z",
+     "start_time": "2024-09-18T13:52:39.573527Z"
+    }
+   },
    "source": [
     "monitor_definition_id = \"drift_v2\"\n",
     "result = wos_client.monitor_instances.list(data_mart_id = data_mart_id,\n",
@@ -1860,7 +3269,20 @@
     "result_json = result._to_dict()\n",
     "drift_monitor_id = result_json[\"monitor_instances\"][0][\"metadata\"][\"id\"]\n",
     "drift_monitor_id"
-   ]
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b'"
+      ]
+     },
+     "execution_count": 68,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 68
   },
   {
    "cell_type": "markdown",
@@ -1871,12 +3293,132 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:45.667702Z",
+     "start_time": "2024-09-18T13:52:41.126466Z"
+    }
+   },
    "source": [
     "wos_client.monitor_instances.show_metrics(monitor_instance_id=drift_monitor_id, space_id=space_id)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b Monitor Runs Metrics from: 2024-09-11 19:22:41.127493  till: 2024-09-18 19:22:41.127501</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>ts</th><th style='border: 1px solid #dddddd'>id</th><th style='border: 1px solid #dddddd'>measurement_id</th><th style='border: 1px solid #dddddd'>value</th><th style='border: 1px solid #dddddd'>lower_limit</th><th style='border: 1px solid #dddddd'>upper_limit</th><th style='border: 1px solid #dddddd'>tags</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>monitor_instance_id</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>target_id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:46.713719+00:00</td><td style='border: 1px solid #dddddd'>records_processed</td><td style='border: 1px solid #dddddd'>c81f8fab-eab5-4f24-8742-3847baa09204</td><td style='border: 1px solid #dddddd'>195.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:jensen_shannon', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_character_count__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:46.713719+00:00</td><td style='border: 1px solid #dddddd'>input_metadata_drift_score</td><td style='border: 1px solid #dddddd'>c81f8fab-eab5-4f24-8742-3847baa09204</td><td style='border: 1px solid #dddddd'>0.3332</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:jensen_shannon', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_character_count__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:53.838695+00:00</td><td style='border: 1px solid #dddddd'>records_processed</td><td style='border: 1px solid #dddddd'>6af69c02-9602-4247-9f25-ae3a4b48630c</td><td style='border: 1px solid #dddddd'>195.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:jensen_shannon', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_word_count__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:53.838695+00:00</td><td style='border: 1px solid #dddddd'>input_metadata_drift_score</td><td style='border: 1px solid #dddddd'>6af69c02-9602-4247-9f25-ae3a4b48630c</td><td style='border: 1px solid #dddddd'>0.3332</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:jensen_shannon', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_word_count__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:50:01.250542+00:00</td><td style='border: 1px solid #dddddd'>records_processed</td><td style='border: 1px solid #dddddd'>5e3661e2-84d1-4a9e-afed-4013ad9f3506</td><td style='border: 1px solid #dddddd'>195.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:jensen_shannon', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_sentence_count__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:50:01.250542+00:00</td><td style='border: 1px solid #dddddd'>input_metadata_drift_score</td><td style='border: 1px solid #dddddd'>5e3661e2-84d1-4a9e-afed-4013ad9f3506</td><td style='border: 1px solid #dddddd'>0.3332</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:jensen_shannon', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_sentence_count__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:50:05.364776+00:00</td><td style='border: 1px solid #dddddd'>records_processed</td><td style='border: 1px solid #dddddd'>355e3887-3dd1-4bdd-a49c-550fe462215b</td><td style='border: 1px solid #dddddd'>195.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:jensen_shannon', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_total_word_length__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:50:05.364776+00:00</td><td style='border: 1px solid #dddddd'>input_metadata_drift_score</td><td style='border: 1px solid #dddddd'>355e3887-3dd1-4bdd-a49c-550fe462215b</td><td style='border: 1px solid #dddddd'>0.3332</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:jensen_shannon', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_total_word_length__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:50:15.553419+00:00</td><td style='border: 1px solid #dddddd'>records_processed</td><td style='border: 1px solid #dddddd'>8b2fbf96-0975-43fa-ba91-b8c481910074</td><td style='border: 1px solid #dddddd'>195.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:total_variation', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_avg_sentence_length__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:50:15.553419+00:00</td><td style='border: 1px solid #dddddd'>input_metadata_drift_score</td><td style='border: 1px solid #dddddd'>8b2fbf96-0975-43fa-ba91-b8c481910074</td><td style='border: 1px solid #dddddd'>0.5687</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>['algorithm_used:total_variation', 'computed_on:payload', 'field_type:input_meta', 'field_name:wos_input_avg_sentence_length__']</td><td style='border: 1px solid #dddddd'>drift_v2</td><td style='border: 1px solid #dddddd'>bb8d6cdf-fe8f-4d71-a9f4-4d2abe67291b</td><td style='border: 1px solid #dddddd'>48925fe3-f0e8-4a44-a7b8-f94f472cc511</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: First 10 records were displayed.\n"
+     ]
+    }
+   ],
+   "execution_count": 69
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Display the model health metrics\n",
+    "### Read the model health monitor instance id\n",
+    "Monitor instance ID of model health metrics is required for reading its metrics."
    ]
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:46.072234Z",
+     "start_time": "2024-09-18T13:52:45.669660Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "monitor_definition_id = \"model_health\"\n",
+    "target_target_id = prod_subscription_id\n",
+    "result = wos_client.monitor_instances.list(data_mart_id=data_mart_id,\n",
+    "                                           monitor_definition_id=monitor_definition_id,\n",
+    "                                           target_target_id=target_target_id,\n",
+    "                                           space_id=space_id).result\n",
+    "result_json = result._to_dict()\n",
+    "mhm_monitor_id = result_json[\"monitor_instances\"][0][\"metadata\"][\"id\"]\n",
+    "mhm_monitor_id"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'8c74bc77-a2f9-43f0-a626-b426fcc8cea1'"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 70
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Displaying the monitor metrics of model health"
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:52:59.162531Z",
+     "start_time": "2024-09-18T13:52:53.739998Z"
+    }
+   },
+   "cell_type": "code",
+   "source": "wos_client.monitor_instances.show_metrics(monitor_instance_id=mhm_monitor_id, space_id=space_id)",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
+      "text/html": [
+       "<HTML>\n",
+       "        <body>\n",
+       "            <h3>8c74bc77-a2f9-43f0-a626-b426fcc8cea1 Monitor Runs Metrics from: 2024-09-11 19:22:53.741004  till: 2024-09-18 19:22:53.741012</h3>\n",
+       "            <table style='border: 1px solid #dddddd; font-family: Courier'>\n",
+       "                <th style='border: 1px solid #dddddd'>ts</th><th style='border: 1px solid #dddddd'>id</th><th style='border: 1px solid #dddddd'>measurement_id</th><th style='border: 1px solid #dddddd'>value</th><th style='border: 1px solid #dddddd'>lower_limit</th><th style='border: 1px solid #dddddd'>upper_limit</th><th style='border: 1px solid #dddddd'>tags</th><th style='border: 1px solid #dddddd'>monitor_definition_id</th><th style='border: 1px solid #dddddd'>monitor_instance_id</th><th style='border: 1px solid #dddddd'>run_id</th><th style='border: 1px solid #dddddd'>target_type</th><th style='border: 1px solid #dddddd'>target_id</th>\n",
+       "                <tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>total_records</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>195.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>median_input_token_count</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>393.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>average_output_token_count</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>4.861538461538461</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>minimum_output_token_count</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>2.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>total_scoring_requests</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>195.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>median_records</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>1.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>average_input_token_count</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>432.625641025641</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>maximum_input_token_count</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>762.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>median_output_token_count</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>4.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr><tr><td style='border: 1px solid #dddddd'>2024-09-18 13:49:37.346160+00:00</td><td style='border: 1px solid #dddddd'>total_output_token_count</td><td style='border: 1px solid #dddddd'>3ed729a4-d8ba-47de-92c6-f9a9bec21530</td><td style='border: 1px solid #dddddd'>948.0</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>None</td><td style='border: 1px solid #dddddd'>[]</td><td style='border: 1px solid #dddddd'>model_health</td><td style='border: 1px solid #dddddd'>8c74bc77-a2f9-43f0-a626-b426fcc8cea1</td><td style='border: 1px solid #dddddd'>fac1ac28-9303-4064-9b69-9ab2d5a5ded9</td><td style='border: 1px solid #dddddd'>subscription</td><td style='border: 1px solid #dddddd'>b77388db-fbd8-4285-8d72-8b1e17621439</td></tr>\n",
+       "            </table>\n",
+       "        </body>\n",
+       "        </HTML>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Note: First 10 records were displayed.\n"
+     ]
+    }
+   ],
+   "execution_count": 71
   },
   {
    "cell_type": "markdown",
@@ -1887,9 +3429,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-09-18T13:53:03.490182Z",
+     "start_time": "2024-09-18T13:53:03.487053Z"
+    }
+   },
    "source": [
     "if not use_cpd:\n",
     "    factsheets_url = \"https://dataplatform.cloud.ibm.com/ml-runtime/deployments/{}/details?space_id={}&context=wx&flush=true\".format(deployment_id, space_id)\n",
@@ -1897,7 +3442,17 @@
     "    factsheets_url = \"{}/ml-runtime/deployments/{}/details?space_id={}&context=wx&flush=true\".format(WML_CREDENTIALS[\"url\"], deployment_id, space_id)\n",
     "    \n",
     "print(\"User can navigate to the published facts in space {}\".format(factsheets_url))"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "User can navigate to the published facts in space https://dataplatform.cloud.ibm.com/ml-runtime/deployments/c44fac44-1f0d-4fa8-b541-ec4420bcddcc/details?space_id=bc592530-1cf0-4e56-9fab-70e0924f6907&context=wx&flush=true\n"
+     ]
+    }
+   ],
+   "execution_count": 72
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Adding cells to display MHM metrics in Prompt Evaluation with watsonxgov.ipynb sample notebooks

- [x] Purpose : updating Prompt Evaluation with watsonxgov.ipynb notebook
- [x] Name according to convention : Prompt Evaluation with watsonxgov
- [ ] Applicable for Cloud:
- [ ] Applicable for CPD/WXG (Specify Version):
- [ ] If applicable for both, separate notebooks created, using right version of python clients ?: 
- [x] Verified notebook runs fine:
- [x] Notebook contains cell outputs
- [x] Verified notebook is using right version of python version. Specify versions used:
   - [x] ibm-watson-openscale:3.0.40

Changes are made in Prompt Evaluation with watsonxgov sample Notebook.ipynb notebook.

- Added MHM metrics display cell at needed places in the notebook attached .
- Replace cell using ibm_watson_machine_learning library with ibm_watsonx_ai library